### PR TITLE
feat: add scrollable, options, methods, events, fix bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix problem where the ratio is not maintained with keepRatio #70
 * Fix that `el is undefined` #73
 * Fix `dragArea`'s caculation
-
+* Fix that `dragStart` method is not work with group
+* Fix that `clickGroup` event occurs when `dragStart` a mousedown target
+* Fix that Moveable is deleted when a single target is changed to multiple targets
 
 ## [0.9.8] - 2019-10-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,25 +3,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.10.0] - 2019-11-07
+## [0.10.0] - 2019-11-08
 ### Added
 * Add `scrollable` props. #39
     * Add `onScroll`, `onScrollGroup` event
-    * Add `scrollContainer` option
-    * Add `getScrollPosition` option
+    * Add `scrollContainer` props
+    * Add `getScrollPosition` props
 * Add `currentTarget` and `inputEvent` on all events #74 #86
 * Add `setState` method #82
 * Add `getRect` method #71
-* Add `renderDirection` option #63
-* Add `className` option #53 #63
+* Add `renderDirection` props #63
+* Add `className` props #53 #63
 * Add `onClick` event
-* Add `onRenderStart`, `onRender`, `onRenderEnd` event #52
-* Add `onRenderGroupStart`, `onRenderGroup`, `onRenderGroupEnd` event #52
+* Add `onRenderStart`, `onRender`, `onRenderEnd` events #52
+* Add `onRenderGroupStart`, `onRenderGroup`, `onRenderGroupEnd` events #52
 
 ### Fixed
 * Fix target's boundingRect matrix caculation with scroll position
 * Fix problem where the ratio is not maintained with keepRatio #70
 * Fix that `el is undefined` #73
+* Fix `dragArea`'s caculation
 
 
 ## [0.9.8] - 2019-10-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.10.0] - 2019-11-08
+## [0.10.0] - 2019-11-09
 ### Added
 * Add `scrollable` props. #39
     * Add `onScroll`, `onScrollGroup` event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.10.0] - 2019-11-07
+### Added
+* Add `scrollable` props. #39
+    * Add `onScroll`, `onScrollGroup` event
+    * Add `scrollContainer` option
+    * Add `getScrollPosition` option
+* Add `currentTarget` and `inputEvent` on all events #74 #86
+* Add `setState` method #82
+* Add `getRect` method #71
+* Add `renderDirection` option #63
+* Add `className` option #53 #63
+* Add `onClick` event
+* Add `onRenderStart`, `onRender`, `onRenderEnd` event #52
+* Add `onRenderGroupStart`, `onRenderGroup`, `onRenderGroupEnd` event #52
+
+### Fixed
+* Fix target's boundingRect matrix caculation with scroll position
+* Fix problem where the ratio is not maintained with keepRatio #70
+* Fix that `el is undefined` #73
+
+
 ## [0.9.8] - 2019-10-26
 ### Fixed
 * Fix that miscaculate static parent's offset position

--- a/handbook/handbook.md
+++ b/handbook/handbook.md
@@ -787,6 +787,7 @@ const moveable = new Moveable(document.body, {
     target: document.querySelector(".target"),
     snappable: true,
     snapThreshold: 5,
+    snapCenter: false,
     bounds: { left: 0, top: 0, bottom: 1000, right: 1000 },
     verticalGuidelines: [100, 200, 300],
     horizontalGuidelines: [0, 100, 200],
@@ -803,6 +804,7 @@ import Moveable from "react-moveable"; // preact-moveable
     target={document.querySelector(".target")}
     snappable={true}
     snapThreshold={5}
+    snapCenter={false}
     bounds={{ left: 0, top: 0, bottom: 1000, right: 1000 }}
     verticalGuidelines={[100, 200, 300]}
     horizontalGuidelines={[0, 100, 200]}
@@ -825,6 +827,7 @@ import {
     [target]="target"
     [snappable]="true"
     [bounds]="bounds"
+    [snapCenter]="false"
     [verticalGuidelines]="verticalGuidelines"
     [horizontalGuidelines]="horizontalGuidelines"
     [elementGuidelines]="elementGuidelines"

--- a/handbook/handbook.md
+++ b/handbook/handbook.md
@@ -3,23 +3,29 @@
 This document explains how to use [moveable](https://github.com/daybrush/moveable).
 
 # Table of Contents
-  * [API Documentation](https://daybrush.com/moveable/release/latest/doc/)
-  * [Introduction](#toc-introduction)
-  * [Basic Support](#toc-support)
-  * [Ables](#toc-ables)
-      * [Draggable](#toc-draggable)
-      * [Resizable](#toc-resizable)
-      * [Scalable](#toc-scalable)
-      * [Rotatable](#toc-rotatable)
-      * [Warpable](#toc-warpable)
-      * [Pinchable](#toc-pinchable)
-      * [Snappable(Guidelines & Boundaries)](#toc-snappable)
-  * [How to use Group](#toc-group)
-    * [Group with Draggable](#toc-group-draggable)
-    * [Group with Resizable](#toc-group-resizable)
-    * [Group with Scalable](#toc-group-scalable)
-    * [Group with Rotatable](#toc-group-rotatable)
-  * [How to use custom css](#toc-custom-css)
+* [API Documentation](https://daybrush.com/moveable/release/latest/doc/)
+* [Introduction](#toc-introduction)
+* [Basic Support](#toc-support)
+* [Events](#toc-events)
+* [Ables](#toc-ables)
+    * [Draggable](#toc-draggable)
+    * [Resizable](#toc-resizable)
+    * [Scalable](#toc-scalable)
+    * [Rotatable](#toc-rotatable)
+    * [Warpable](#toc-warpable)
+    * [Pinchable](#toc-pinchable)
+    * [Snappable(Guidelines & Boundaries)](#toc-snappable)
+    * [Scrollable](#toc-scrollable)
+* [How to use Group](#toc-group)
+* [Group with Draggable](#toc-group-draggable)
+* [Group with Resizable](#toc-group-resizable)
+* [Group with Scalable](#toc-group-scalable)
+* [Group with Rotatable](#toc-group-rotatable)
+* [How to use custom css](#toc-custom-css)
+    * [Show Partial ControlBox](#toc-directions)
+    * [Set className](#toc-classname)
+    * [Use important](#toc-important)
+    * [Moveable's Default CSS](#toc-defaultcss)
 
 
 # <a id="toc-introduction"></a>Introduction
@@ -47,6 +53,26 @@ If the transform overlaps from the root element to the parent element, the dista
 
 If you have any questions or requests or want to contribute to `moveable` or other packages, please write the [issue](https://github.com/daybrush/moveable/issues) or give me a Pull Request freely.
 
+# <a id="toc-events></a> Events
+
+All events in moveable have the following properties by default:
+
+* **currentTarget**: An instance of Moveable that occur an event.
+* **target**: The target of the event where the MouseEvent or TouchEvent occurred.
+* **clientX**: The x coordinate where the MouseEvent or TouchEvent occurred.
+* **clientY**: The y coordinate where the MouseEvent or TouchEvent occurred.
+* **datas**: Information can be shared between the same event. (ex: `dragStart`, `drag`, `dragEnd`)
+* **inputEvent**: MouseEvent or TouchEvent source where the event occurred.
+```ts
+export interface OnEvent {
+    currentTarget: MoveableInterface;
+    target: HTMLElement | SVGElement;
+    clientX: number;
+    clientY: number;
+    datas: IObject<any>;
+    inputEvent: any;
+}
+```
 
 # <a id="toc-ables"></a>Ables
 You can Drag, Resize, Scale, Rotate, Warp, Pinch, Snap.
@@ -814,6 +840,97 @@ export class AppComponent {
 ```
 
 
+## <a id="toc-scrollable"></a>Scrollable
+
+**Scrollable** indicates whether or not target can be scrolled to the scroll container (default: false)
+
+### Events
+* [onScroll](https://daybrush.com/moveable/release/latest/doc/Moveable.html#.event:scroll): When the drag cursor leaves the scrollContainer, the `scroll` event occur to scroll.
+* [onScrollGroup](https://daybrush.com/moveable/release/latest/doc/Moveable.html#.event:scrollGroup): When the drag cursor leaves the scrollContainer, the `scrollGroup` event occur to scroll in group.
+
+### Options
+* [scrollContainer](https://daybrush.com/moveable/release/latest/doc/Moveable.html#scrollContainer): The container to which scroll is applied (default: container)
+* [scrollThreshold](https://daybrush.com/moveable/release/latest/doc/Moveable.html#scrollThreshold): Expand the range of the scroll check area. (default: 0)
+* [getScrollPosition](https://daybrush.com/moveable/release/latest/doc/Moveable.html#getScrollPosition): Sets a function to get the scroll position. (default: Function)
+
+
+### Vanilla Example
+
+```ts
+const moveable = new Moveable(document.body, {
+    target: document.querySelector(".target"),
+    scrollable: true,
+    scrollContainer: document.body,
+    scrollThreshold: 0,
+    getScrollPosition: ({ scrollContainer }) => ([scrollContainer.scrollLeft, scrollContainer.scrollTop]),
+}).on("scroll", ({ scrollContainer, direction }) => {
+    scrollContainer.scrollLeft += direction[0] * 10;
+    scrollContainer.scrollTop += direction[1] * 10;
+}).on("scrollGroup", ({ scrollContainer, direction }) => {
+    scrollContainer.scrollLeft += direction[0] * 10;
+    scrollContainer.scrollTop += direction[1] * 10;
+});
+```
+
+### React & Preact Example
+
+```tsx
+import Moveable from "react-moveable"; // preact-moveable
+
+<Moveable
+    target={document.querySelector(".target")}
+    scrollable={true}
+    container={document.body}
+    scrollContainer={document.body}
+    scrollThreshold={0}
+    getScrollPosition={({ scrollContainer }) => ([scrollContainer.scrollLeft, scrollContainer.scrollTop])}
+    onScroll={({ scrollContainer, direction }) => {
+        scrollContainer.scrollLeft += direction[0] * 10;
+        scrollContainer.scrollTop += direction[1] * 10;
+    }}
+    onScrollGroup={({ scrollContainer, direction }) => {
+        scrollContainer.scrollLeft += direction[0] * 10;
+        scrollContainer.scrollTop += direction[1] * 10;
+    }}
+    />
+```
+
+
+### Angular Example
+```ts
+import {
+    NgxMoveableModule,
+    NgxMoveableComponent,
+} from "ngx-moveable";
+
+@Component({
+    selector: 'AppComponent',
+    template: `
+<div #target class="target">target</div>
+<ngx-moveable
+    [target]="target"
+    [container]="container"
+    [scrollable]="true"
+    [scrollContainer]="container"
+    [scrollThreshold]="0"
+    [getScrollPosition]="getScrollPosition"
+    (scroll)="onScroll($event)"
+    (scrollGroup)="onScroll($event)"
+    />
+`,
+})
+export class AppComponent {
+    container = document.body;
+    getScrollPosition({ scrollContainer }) {
+        return [scrollContainer.scrollLeft, scrollContainer.scrollTop];
+    }
+    onScroll({ scrollContainer, direction }) {
+        scrollContainer.scrollLeft += direction[0] * 10;
+        scrollContainer.scrollTop += direction[1] * 10;
+    }
+}
+```
+
 # <a id="toc-group"></a> How to use Group
 
 **Groupable** indicates Whether the targets can be moved in group with draggable, resizable, scalable, rotatable.
@@ -1440,7 +1557,39 @@ export class AppComponent implements OnInit {
 
 # <a id="toc-custom-css"></a>✨ How to use custom CSS
 
-If you want to custom CSS, use **`!important`**.
+
+## <a id="toc-directions"></a>Show Partial Control Box
+### Options
+* [renderDirections](https://daybrush.com/moveable/release/latest/doc/Moveable.html#.event:renderDirections) : Set directions to show the control box. (default: ["n", "nw", "ne", "s", "se", "sw", "e", "w"])
+
+### Vanilla Example
+```ts
+import Moveable from "moveable";
+
+const moveable = new Moveable(document.body, {
+    renderDirections: ["n", "nw", "ne", "s", "se", "sw", "e", "w"],
+});
+
+moveable.renderDirections = ["nw", "ne", "sw", "se"];
+```
+
+## <a id="toc-classname"></a>Set className
+### Options
+* [className](https://daybrush.com/moveable/release/latest/doc/Moveable.html#.event:className) : You can specify the className of the moveable controlbox. (default: "")
+
+### Vanilla Example
+```ts
+import Moveable from "moveable";
+
+const moveable = new Moveable(document.body, {
+    className: "moveable1",
+});
+
+moveable.classname = "moveable2";
+```
+
+## <a id="toc-important"></a>Use important
+* If you want to custom CSS, use **`!important`**.
 
 ```css
 .moveable-control {
@@ -1451,7 +1600,8 @@ If you want to custom CSS, use **`!important`**.
 }
 ```
 
-## moveable-line
+## <a id="toc-defaultcss"></a>Moveable's Default CSS
+### moveable-line
 
 ```css
 .moveable-line {
@@ -1473,7 +1623,7 @@ If you want to custom CSS, use **`!important`**.
     transform-origin: 0.5px 39.5px;
 }
 ```
-## moveable-control
+### moveable-control
 
 ```css
 .moveable-control {
@@ -1492,7 +1642,7 @@ If you want to custom CSS, use **`!important`**.
 
 ![](../demo/images/control.png)
 
-## moveable-rotataion
+### moveable-rotataion
 
 ```css
 /* moveable-rotation */
@@ -1503,7 +1653,7 @@ If you want to custom CSS, use **`!important`**.
 }
 ```
 
-## moveable-origin
+### moveable-origin
 ```css
 .moveable-control.moveable-origin {
     border-color: #f55;
@@ -1516,7 +1666,7 @@ If you want to custom CSS, use **`!important`**.
 }
 ```
 
-## moveable-direction
+### moveable-direction
 
 ```css
 .moveable-direction.moveable-e, .moveable-direction.moveable-w {
@@ -1534,7 +1684,7 @@ If you want to custom CSS, use **`!important`**.
 ```
 
 
-## Default CSS
+### Default CSS
 
 ```css
 .moveable-control-box {

--- a/handbook/handbook.md
+++ b/handbook/handbook.md
@@ -1686,8 +1686,10 @@ moveable.classname = "moveable2";
 
 ### Default CSS
 
+* `rCS1cac4f3` is The hash value of the class name, which can be changed at any time.
+
 ```css
-.moveable-control-box {
+.rCS1cac4f3 {
 	position: fixed;
 	width: 0;
 	height: 0;
@@ -1695,15 +1697,14 @@ moveable.classname = "moveable2";
 	top: 0;
 	z-index: 3000;
 }
-.moveable-control-box .moveable-control-box{
+.rCS1cac4f3 .moveable-control-box{
     z-index: 0;
 }
-.moveable-control-box .moveable-line,
-.moveable-control-box .moveable-control{
+.rCS1cac4f3 .moveable-line, .rCS1cac4f3 .moveable-control{
 	left: 0;
 	top: 0;
 }
-.moveable-control-box .moveable-control{
+.rCS1cac4f3 .moveable-control{
 	position: absolute;
 	width: 14px;
 	height: 14px;
@@ -1715,32 +1716,32 @@ moveable.classname = "moveable2";
     margin-left: -7px;
     z-index: 10;
 }
-.moveable-control-box .moveable-line{
+.rCS1cac4f3 .moveable-line{
 	position: absolute;
 	width: 1px;
 	height: 1px;
 	background: #4af;
 	transform-origin: 0px 0.5px;
 }
-.moveable-control-box .moveable-line.moveable-rotation-line{
+.rCS1cac4f3 .moveable-line.moveable-rotation-line{
 	height: 40px;
 	width: 1px;
 	transform-origin: 0.5px 39.5px;
 }
-.moveable-control-box .moveable-line.moveable-rotation-line .moveable-control{
+.rCS1cac4f3 .moveable-line.moveable-rotation-line .moveable-control{
 	border-color: #4af;
 	background:#fff;
 	cursor: alias;
 }
-.moveable-control-box .moveable-line.moveable-vertical.moveable-bold{
+.rCS1cac4f3 .moveable-line.moveable-vertical.moveable-bold{
     width: 2px;
     margin-left: -1px;
 }
-.moveable-control-box .moveable-line.moveable-horizontal.moveable-bold{
+.rCS1cac4f3 .moveable-line.moveable-horizontal.moveable-bold{
     height: 2px;
     margin-top: -1px;
 }
-.moveable-control-box .moveable-control.moveable-origin{
+.rCS1cac4f3 .moveable-control.moveable-origin{
 	border-color: #f55;
 	background: #fff;
 	width: 12px;
@@ -1749,47 +1750,46 @@ moveable.classname = "moveable2";
 	margin-left: -6px;
 	pointer-events: none;
 }
-.moveable-control-box .moveable-direction.moveable-e,
-.moveable-control-box .moveable-direction.moveable-w{
+.rCS1cac4f3 .moveable-direction.moveable-e,
+.rCS1cac4f3 .moveable-direction.moveable-w{
 	cursor: ew-resize;
 }
-.moveable-control-box .moveable-direction.moveable-s,
-.moveable-control-box .moveable-direction.moveable-n{
+.rCS1cac4f3 .moveable-direction.moveable-s,
+.rCS1cac4f3 .moveable-direction.moveable-n{
 	cursor: ns-resize;
 }
-.moveable-control-box .moveable-direction.moveable-nw,
-.moveable-control-box .moveable-direction.moveable-se, .rCSw4d7my.moveable-reverse .moveable-direction.moveable-ne, .rCSw4d7my.moveable-reverse .moveable-direction.moveable-sw{
+.rCS1cac4f3 .moveable-direction.moveable-nw,
+.rCS1cac4f3 .moveable-direction.moveable-se,
+.rCS1cac4f3.moveable-reverse .moveable-direction.moveable-ne,
+.rCS1cac4f3.moveable-reverse .moveable-direction.moveable-sw {
 	cursor: nwse-resize;
 }
-.moveable-control-box .moveable-direction.moveable-ne,
-.moveable-control-box .moveable-direction.moveable-sw, .rCSw4d7my.moveable-reverse .moveable-direction.moveable-nw, .rCSw4d7my.moveable-reverse .moveable-direction.moveable-se{
+.rCS1cac4f3 .moveable-direction.moveable-ne,
+.rCS1cac4f3 .moveable-direction.moveable-sw,
+.rCS1cac4f3.moveable-reverse .moveable-direction.moveable-nw,
+.rCS1cac4f3.moveable-reverse .moveable-direction.moveable-se {
 	cursor: nesw-resize;
 }
-.moveable-control-box .moveable-group{
+.rCS1cac4f3 .moveable-group{
     z-index: -1;
 }
-.moveable-control-box .moveable-area{
+.rCS1cac4f3 .moveable-area{
     position: absolute;
 }
-.moveable-control-box .moveable-area.moveable-avoid,
-.moveable-control-box .moveable-area.moveable-avoid:before,
-.moveable-control-box .moveable-area.moveable-avoid:after{
-    transform-origin: 50% calc(100% + 20px);
-}
-.moveable-control-box .moveable-area.moveable-avoid:before,
-.moveable-control-box .moveable-area.moveable-avoid:after{
-    content: "";
-    top: 0px;
-    left: 0px;
+.rCS1cac4f3 .moveable-area-pieces{
     position: absolute;
-    width: 100%;
-    height: 100%;
+    top: 0;
+    left: 0;
+    display: none;
 }
-.moveable-control-box .moveable-area.moveable-avoid:before{
-    transform: rotate(120deg);
+.rCS1cac4f3 .moveable-area.moveable-avoid{
+    pointer-events: none;
 }
-.moveable-control-box .moveable-area.moveable-avoid:after{
-    transform: rotate(-120deg);
+.rCS1cac4f3 .moveable-area.moveable-avoid+.moveable-area-pieces {
+    display: block;
+}
+.rCS1cac4f3 .moveable-area-piece{
+    position: absolute;
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moveable",
-  "version": "0.10.0-rc8",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1050,13 +1050,13 @@
       }
     },
     "preact-moveable": {
-      "version": "0.12.5-rc3",
-      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.5-rc3.tgz",
-      "integrity": "sha512-yqIeapSyw4t5DwyHxgok3V30nUP20GNFgVApwrcYgCV/TwSSs9U7ysTfO6+IQqthD7Bh/sOyQTI4//hHeGa0kQ==",
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.6.tgz",
+      "integrity": "sha512-yTiwyPyI4IoWLRTWi6AJk3KPkG99AUaIY44kolCST5eDWXZnbo3QVjQ+PYQSHsHZ61wu2D8zYdq/1L0WU7pzfg==",
       "requires": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.6-rc2"
+        "react-moveable": "^0.13.6"
       }
     },
     "preact-render-to-string": {
@@ -1138,9 +1138,9 @@
       "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     },
     "react-moveable": {
-      "version": "0.13.6-rc2",
-      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.6-rc2.tgz",
-      "integrity": "sha512-R25Lfb6ZS2TFR60LP+ao4fJu9gHY8FTGUHbHB06rvh/WhJJzpjEuPs4jsFw9qKQzqHbgKhQWgFWMZKhitf/NLw==",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.6.tgz",
+      "integrity": "sha512-0QsO8/H8ueRN25yo83iFPiiKaF/WZgmzudOokcR0w1LkmErkLnpDqW3V7cXXH8JXdlOkMmWEm6Cgg3DT9N5mqw==",
       "requires": {
         "@daybrush/drag": "^0.11.0",
         "@daybrush/utils": "^0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1050,13 +1050,13 @@
       }
     },
     "preact-moveable": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.4.tgz",
-      "integrity": "sha512-G79RZn+b/D7UgiXYlteXsslHUep/QUDL9kVavYeLZz8KM0b4qHqOPCnNKEY/n7IQS3v+1Ub2clO84W8ZOTuXCw==",
+      "version": "0.12.5-rc",
+      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.5-rc.tgz",
+      "integrity": "sha512-8eIMSLOxQBt2O9fA2j7MK0ISHASwMbms8EYNUp8+z5CkJAJeUdP3sRcwxfmcqjMI+HSCvFnjSNOc0wAhia+QaQ==",
       "requires": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.5"
+        "react-moveable": "^0.13.6-rc"
       }
     },
     "preact-render-to-string": {
@@ -1138,9 +1138,9 @@
       "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     },
     "react-moveable": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.5.tgz",
-      "integrity": "sha512-gf+ypPCWGnDTDx9pwSqdAEMMO9jx+nK2b0r/mR67j71j8DeInjPSGitGGbt+Eu/vzZW664GPB47OQ1vkZAo0HQ==",
+      "version": "0.13.6-rc",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.6-rc.tgz",
+      "integrity": "sha512-exRHKbBrqdvSIRpgjqfOxxvG5CHksiFAP6sE1uOYfQgKBOYc3KuCDtVWHljmPtEy8TeAczZ4OOlKYCuDDi0h6Q==",
       "requires": {
         "@daybrush/drag": "^0.11.0",
         "@daybrush/utils": "^0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moveable",
-  "version": "0.10.0-rc7",
+  "version": "0.10.0-rc8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1050,13 +1050,13 @@
       }
     },
     "preact-moveable": {
-      "version": "0.12.5-rc2",
-      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.5-rc2.tgz",
-      "integrity": "sha512-mZHMW8IQkpdH3ssLgQoR5GWY00BiOIsycKjl2nTBGvK2Znrz+ALE3vCXrPuROnX5zO3sCHjkuX5Xh/krgFsZ3g==",
+      "version": "0.12.5-rc3",
+      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.5-rc3.tgz",
+      "integrity": "sha512-yqIeapSyw4t5DwyHxgok3V30nUP20GNFgVApwrcYgCV/TwSSs9U7ysTfO6+IQqthD7Bh/sOyQTI4//hHeGa0kQ==",
       "requires": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.6-rc"
+        "react-moveable": "^0.13.6-rc2"
       }
     },
     "preact-render-to-string": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moveable",
-  "version": "0.10.0",
+  "version": "0.10.0-rc7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1050,9 +1050,9 @@
       }
     },
     "preact-moveable": {
-      "version": "0.12.5-rc",
-      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.5-rc.tgz",
-      "integrity": "sha512-8eIMSLOxQBt2O9fA2j7MK0ISHASwMbms8EYNUp8+z5CkJAJeUdP3sRcwxfmcqjMI+HSCvFnjSNOc0wAhia+QaQ==",
+      "version": "0.12.5-rc2",
+      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.5-rc2.tgz",
+      "integrity": "sha512-mZHMW8IQkpdH3ssLgQoR5GWY00BiOIsycKjl2nTBGvK2Znrz+ALE3vCXrPuROnX5zO3sCHjkuX5Xh/krgFsZ3g==",
       "requires": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
@@ -1138,9 +1138,9 @@
       "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     },
     "react-moveable": {
-      "version": "0.13.6-rc",
-      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.6-rc.tgz",
-      "integrity": "sha512-exRHKbBrqdvSIRpgjqfOxxvG5CHksiFAP6sE1uOYfQgKBOYc3KuCDtVWHljmPtEy8TeAczZ4OOlKYCuDDi0h6Q==",
+      "version": "0.13.6-rc2",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.6-rc2.tgz",
+      "integrity": "sha512-R25Lfb6ZS2TFR60LP+ao4fJu9gHY8FTGUHbHB06rvh/WhJJzpjEuPs4jsFw9qKQzqHbgKhQWgFWMZKhitf/NLw==",
       "requires": {
         "@daybrush/drag": "^0.11.0",
         "@daybrush/utils": "^0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1050,13 +1050,13 @@
       }
     },
     "preact-moveable": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.2.tgz",
-      "integrity": "sha512-VljdSqYhNpsO0J5gLSlHudqio6qmodp37dJqIr/ejETGEFlXIu2FnpctGnNThN3aWykAYuaOftwbl9Hdt+tCWA==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.3.tgz",
+      "integrity": "sha512-yZdnKvEyMjvfF95whCFbV8wRZWut8zqDkNRR1bQeXqJ0mbOC0w10MUyvnPh08cIrgo22hnT1w3Mio9T1/1urxQ==",
       "requires": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.3"
+        "react-moveable": "^0.13.4"
       }
     },
     "preact-render-to-string": {
@@ -1138,9 +1138,9 @@
       "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     },
     "react-moveable": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.3.tgz",
-      "integrity": "sha512-B+tWESHPbH9Pm+3bjBQQwkZiV37UdZAFFpBeg/2aFTPtQuyiw3MLfRsIPAmTEfthftw+cPrTNKIB62qYrsJ17Q==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.4.tgz",
+      "integrity": "sha512-kW3OSwNvzslhOiR2aplwToeTrkO5M+w3514Y5kH9Kn/8CnN4k4RS2pQjFcw/3Tu70kQCgKh2WYbUjbFSbmaE/A==",
       "requires": {
         "@daybrush/drag": "^0.11.0",
         "@daybrush/utils": "^0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moveable",
-  "version": "0.9.8",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1050,18 +1050,13 @@
       }
     },
     "preact-moveable": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.11.14.tgz",
-      "integrity": "sha512-eRYeK2FYeJS9UHhFsvql5GFf8eLlaMWuoC4k57NnLwmzt7+VTQmHJ/zCF2rcds3e9CAUq2es5x13xRi2W5V4aA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.1.tgz",
+      "integrity": "sha512-ejgrln9dBNl5B4UVprfsCwNDOLQAYD/I4BuUt8/ZQ/AR6HtOuGS7o9iDLHuRcBNkPdZ8eluq1X6t1LjvglsdjQ==",
       "requires": {
-        "@daybrush/drag": "^0.10.2",
-        "@daybrush/utils": "^0.10.1",
-        "@egjs/agent": "^2.1.5",
-        "@egjs/children-differ": "^1.0.0",
-        "framework-utils": "^0.2.1",
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.12.14"
+        "react-moveable": "^0.13.2"
       }
     },
     "preact-render-to-string": {
@@ -1143,11 +1138,11 @@
       "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     },
     "react-moveable": {
-      "version": "0.12.14",
-      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.12.14.tgz",
-      "integrity": "sha512-CU0QNRLV4Qh/E99abaGAwnMVuk2Va+KVPTDrMDiivVnW0wsprvSm4dyICQZESqk+lqiOM+CZB686EXClZ0zaBA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.2.tgz",
+      "integrity": "sha512-KKbc/N5eBMsJOEgbumZVyX4Bwjp/0Rg261NJzex8TV/QQ5e5qhxzRBPC8U4yi5gMcS2tc9LKxVPovfy9LR17eg==",
       "requires": {
-        "@daybrush/drag": "^0.10.2",
+        "@daybrush/drag": "^0.11.0",
         "@daybrush/utils": "^0.10.0",
         "@egjs/agent": "^2.1.5",
         "@egjs/children-differ": "^1.0.0",
@@ -1155,6 +1150,16 @@
         "framework-utils": "^0.2.1",
         "react-css-styler": "^0.4.0",
         "react-pure-props": "^0.1.5"
+      },
+      "dependencies": {
+        "@daybrush/drag": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/@daybrush/drag/-/drag-0.11.0.tgz",
+          "integrity": "sha512-P3JhEJv9wwi8Naah55dvjd+3Kj3JSaLvemYkbH6qUEEowY9RN889XbDSKWiZ2WCQoz6oZoO+s6K2sIKF+jrfzA==",
+          "requires": {
+            "@daybrush/utils": "^0.10.0"
+          }
+        }
       }
     },
     "react-pure-props": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1050,13 +1050,13 @@
       }
     },
     "preact-moveable": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.3.tgz",
-      "integrity": "sha512-yZdnKvEyMjvfF95whCFbV8wRZWut8zqDkNRR1bQeXqJ0mbOC0w10MUyvnPh08cIrgo22hnT1w3Mio9T1/1urxQ==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.4.tgz",
+      "integrity": "sha512-G79RZn+b/D7UgiXYlteXsslHUep/QUDL9kVavYeLZz8KM0b4qHqOPCnNKEY/n7IQS3v+1Ub2clO84W8ZOTuXCw==",
       "requires": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.4"
+        "react-moveable": "^0.13.5"
       }
     },
     "preact-render-to-string": {
@@ -1138,9 +1138,9 @@
       "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     },
     "react-moveable": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.4.tgz",
-      "integrity": "sha512-kW3OSwNvzslhOiR2aplwToeTrkO5M+w3514Y5kH9Kn/8CnN4k4RS2pQjFcw/3Tu70kQCgKh2WYbUjbFSbmaE/A==",
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.5.tgz",
+      "integrity": "sha512-gf+ypPCWGnDTDx9pwSqdAEMMO9jx+nK2b0r/mR67j71j8DeInjPSGitGGbt+Eu/vzZW664GPB47OQ1vkZAo0HQ==",
       "requires": {
         "@daybrush/drag": "^0.11.0",
         "@daybrush/utils": "^0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,9 +184,9 @@
       }
     },
     "@daybrush/drag": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@daybrush/drag/-/drag-0.10.2.tgz",
-      "integrity": "sha512-aB1NH6k8MFDEtS0HWNfppBO2W9gW7a8HsDCBgsusTsHXYxyBFSlspXm9wKrQWSzM34DPk3SNry5QF9oF3zamtg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@daybrush/drag/-/drag-0.11.0.tgz",
+      "integrity": "sha512-P3JhEJv9wwi8Naah55dvjd+3Kj3JSaLvemYkbH6qUEEowY9RN889XbDSKWiZ2WCQoz6oZoO+s6K2sIKF+jrfzA==",
       "requires": {
         "@daybrush/utils": "^0.10.0"
       }
@@ -1050,13 +1050,13 @@
       }
     },
     "preact-moveable": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.1.tgz",
-      "integrity": "sha512-ejgrln9dBNl5B4UVprfsCwNDOLQAYD/I4BuUt8/ZQ/AR6HtOuGS7o9iDLHuRcBNkPdZ8eluq1X6t1LjvglsdjQ==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/preact-moveable/-/preact-moveable-0.12.2.tgz",
+      "integrity": "sha512-VljdSqYhNpsO0J5gLSlHudqio6qmodp37dJqIr/ejETGEFlXIu2FnpctGnNThN3aWykAYuaOftwbl9Hdt+tCWA==",
       "requires": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.2"
+        "react-moveable": "^0.13.3"
       }
     },
     "preact-render-to-string": {
@@ -1138,9 +1138,9 @@
       "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     },
     "react-moveable": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.2.tgz",
-      "integrity": "sha512-KKbc/N5eBMsJOEgbumZVyX4Bwjp/0Rg261NJzex8TV/QQ5e5qhxzRBPC8U4yi5gMcS2tc9LKxVPovfy9LR17eg==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.3.tgz",
+      "integrity": "sha512-B+tWESHPbH9Pm+3bjBQQwkZiV37UdZAFFpBeg/2aFTPtQuyiw3MLfRsIPAmTEfthftw+cPrTNKIB62qYrsJ17Q==",
       "requires": {
         "@daybrush/drag": "^0.11.0",
         "@daybrush/utils": "^0.10.0",
@@ -1150,16 +1150,6 @@
         "framework-utils": "^0.2.1",
         "react-css-styler": "^0.4.0",
         "react-pure-props": "^0.1.5"
-      },
-      "dependencies": {
-        "@daybrush/drag": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/@daybrush/drag/-/drag-0.11.0.tgz",
-          "integrity": "sha512-P3JhEJv9wwi8Naah55dvjd+3Kj3JSaLvemYkbH6qUEEowY9RN889XbDSKWiZ2WCQoz6oZoO+s6K2sIKF+jrfzA==",
-          "requires": {
-            "@daybrush/utils": "^0.10.0"
-          }
-        }
       }
     },
     "react-pure-props": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "homepage": "https://github.com/daybrush/moveable#readme",
   "dependencies": {
     "@egjs/component": "^2.1.2",
-    "preact-moveable": "^0.12.2"
+    "preact-moveable": "^0.12.3"
   },
   "devDependencies": {
     "@daybrush/builder": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moveable",
-  "version": "0.9.8",
+  "version": "0.10.0",
   "description": "Moveable is Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable, Snappable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",
@@ -54,13 +54,8 @@
   },
   "homepage": "https://github.com/daybrush/moveable#readme",
   "dependencies": {
-    "@daybrush/drag": "^0.10.2",
-    "@daybrush/utils": "^0.10.1",
-    "@egjs/agent": "^2.1.5",
-    "@egjs/children-differ": "^1.0.0",
     "@egjs/component": "^2.1.2",
-    "framework-utils": "^0.2.1",
-    "preact-moveable": "^0.11.14"
+    "preact-moveable": "^0.12.1"
   },
   "devDependencies": {
     "@daybrush/builder": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "homepage": "https://github.com/daybrush/moveable#readme",
   "dependencies": {
     "@egjs/component": "^2.1.2",
-    "preact-moveable": "^0.12.3"
+    "preact-moveable": "^0.12.4"
   },
   "devDependencies": {
     "@daybrush/builder": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moveable",
-  "version": "0.10.0-rc7",
+  "version": "0.10.0-rc8",
   "description": "Moveable is Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable, Snappable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",
@@ -55,7 +55,7 @@
   "homepage": "https://github.com/daybrush/moveable#readme",
   "dependencies": {
     "@egjs/component": "^2.1.2",
-    "preact-moveable": "^0.12.5-rc2"
+    "preact-moveable": "^0.12.5-rc3"
   },
   "devDependencies": {
     "@daybrush/builder": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moveable",
-  "version": "0.10.0-rc8",
+  "version": "0.10.0",
   "description": "Moveable is Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable, Snappable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",
@@ -55,7 +55,7 @@
   "homepage": "https://github.com/daybrush/moveable#readme",
   "dependencies": {
     "@egjs/component": "^2.1.2",
-    "preact-moveable": "^0.12.5-rc3"
+    "preact-moveable": "^0.12.6"
   },
   "devDependencies": {
     "@daybrush/builder": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moveable",
-  "version": "0.10.0-rc6",
+  "version": "0.10.0-rc7",
   "description": "Moveable is Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable, Snappable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",
@@ -55,7 +55,7 @@
   "homepage": "https://github.com/daybrush/moveable#readme",
   "dependencies": {
     "@egjs/component": "^2.1.2",
-    "preact-moveable": "^0.12.5-rc"
+    "preact-moveable": "^0.12.5-rc2"
   },
   "devDependencies": {
     "@daybrush/builder": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "homepage": "https://github.com/daybrush/moveable#readme",
   "dependencies": {
     "@egjs/component": "^2.1.2",
-    "preact-moveable": "^0.12.1"
+    "preact-moveable": "^0.12.2"
   },
   "devDependencies": {
     "@daybrush/builder": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moveable",
-  "version": "0.10.0",
+  "version": "0.10.0-rc6",
   "description": "Moveable is Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable, Snappable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",
@@ -55,7 +55,7 @@
   "homepage": "https://github.com/daybrush/moveable#readme",
   "dependencies": {
     "@egjs/component": "^2.1.2",
-    "preact-moveable": "^0.12.4"
+    "preact-moveable": "^0.12.5-rc"
   },
   "devDependencies": {
     "@daybrush/builder": "^0.1.2",

--- a/packages/preact-moveable/package-lock.json
+++ b/packages/preact-moveable/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.2",
+    "version": "0.12.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -777,9 +777,9 @@
             "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
         },
         "react-moveable": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.3.tgz",
-            "integrity": "sha512-B+tWESHPbH9Pm+3bjBQQwkZiV37UdZAFFpBeg/2aFTPtQuyiw3MLfRsIPAmTEfthftw+cPrTNKIB62qYrsJ17Q==",
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.4.tgz",
+            "integrity": "sha512-kW3OSwNvzslhOiR2aplwToeTrkO5M+w3514Y5kH9Kn/8CnN4k4RS2pQjFcw/3Tu70kQCgKh2WYbUjbFSbmaE/A==",
             "requires": {
                 "@daybrush/drag": "^0.11.0",
                 "@daybrush/utils": "^0.10.0",

--- a/packages/preact-moveable/package-lock.json
+++ b/packages/preact-moveable/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.5-rc",
+    "version": "0.12.5-rc2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/preact-moveable/package-lock.json
+++ b/packages/preact-moveable/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -777,9 +777,9 @@
             "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
         },
         "react-moveable": {
-            "version": "0.13.2",
-            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.2.tgz",
-            "integrity": "sha512-KKbc/N5eBMsJOEgbumZVyX4Bwjp/0Rg261NJzex8TV/QQ5e5qhxzRBPC8U4yi5gMcS2tc9LKxVPovfy9LR17eg==",
+            "version": "0.13.3",
+            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.3.tgz",
+            "integrity": "sha512-B+tWESHPbH9Pm+3bjBQQwkZiV37UdZAFFpBeg/2aFTPtQuyiw3MLfRsIPAmTEfthftw+cPrTNKIB62qYrsJ17Q==",
             "requires": {
                 "@daybrush/drag": "^0.11.0",
                 "@daybrush/utils": "^0.10.0",

--- a/packages/preact-moveable/package-lock.json
+++ b/packages/preact-moveable/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.3",
+    "version": "0.12.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -777,9 +777,9 @@
             "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
         },
         "react-moveable": {
-            "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.4.tgz",
-            "integrity": "sha512-kW3OSwNvzslhOiR2aplwToeTrkO5M+w3514Y5kH9Kn/8CnN4k4RS2pQjFcw/3Tu70kQCgKh2WYbUjbFSbmaE/A==",
+            "version": "0.13.5",
+            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.5.tgz",
+            "integrity": "sha512-gf+ypPCWGnDTDx9pwSqdAEMMO9jx+nK2b0r/mR67j71j8DeInjPSGitGGbt+Eu/vzZW664GPB47OQ1vkZAo0HQ==",
             "requires": {
                 "@daybrush/drag": "^0.11.0",
                 "@daybrush/utils": "^0.10.0",

--- a/packages/preact-moveable/package-lock.json
+++ b/packages/preact-moveable/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.11.14",
+    "version": "0.12.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -143,9 +143,9 @@
             }
         },
         "@daybrush/drag": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/@daybrush/drag/-/drag-0.10.2.tgz",
-            "integrity": "sha512-aB1NH6k8MFDEtS0HWNfppBO2W9gW7a8HsDCBgsusTsHXYxyBFSlspXm9wKrQWSzM34DPk3SNry5QF9oF3zamtg==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@daybrush/drag/-/drag-0.11.0.tgz",
+            "integrity": "sha512-P3JhEJv9wwi8Naah55dvjd+3Kj3JSaLvemYkbH6qUEEowY9RN889XbDSKWiZ2WCQoz6oZoO+s6K2sIKF+jrfzA==",
             "requires": {
                 "@daybrush/utils": "^0.10.0"
             }
@@ -777,11 +777,11 @@
             "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
         },
         "react-moveable": {
-            "version": "0.12.14",
-            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.12.14.tgz",
-            "integrity": "sha512-CU0QNRLV4Qh/E99abaGAwnMVuk2Va+KVPTDrMDiivVnW0wsprvSm4dyICQZESqk+lqiOM+CZB686EXClZ0zaBA==",
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.2.tgz",
+            "integrity": "sha512-KKbc/N5eBMsJOEgbumZVyX4Bwjp/0Rg261NJzex8TV/QQ5e5qhxzRBPC8U4yi5gMcS2tc9LKxVPovfy9LR17eg==",
             "requires": {
-                "@daybrush/drag": "^0.10.2",
+                "@daybrush/drag": "^0.11.0",
                 "@daybrush/utils": "^0.10.0",
                 "@egjs/agent": "^2.1.5",
                 "@egjs/children-differ": "^1.0.0",

--- a/packages/preact-moveable/package-lock.json
+++ b/packages/preact-moveable/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.4",
+    "version": "0.12.5-rc",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -777,9 +777,9 @@
             "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
         },
         "react-moveable": {
-            "version": "0.13.5",
-            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.5.tgz",
-            "integrity": "sha512-gf+ypPCWGnDTDx9pwSqdAEMMO9jx+nK2b0r/mR67j71j8DeInjPSGitGGbt+Eu/vzZW664GPB47OQ1vkZAo0HQ==",
+            "version": "0.13.6-rc",
+            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.6-rc.tgz",
+            "integrity": "sha512-exRHKbBrqdvSIRpgjqfOxxvG5CHksiFAP6sE1uOYfQgKBOYc3KuCDtVWHljmPtEy8TeAczZ4OOlKYCuDDi0h6Q==",
             "requires": {
                 "@daybrush/drag": "^0.11.0",
                 "@daybrush/utils": "^0.10.0",

--- a/packages/preact-moveable/package-lock.json
+++ b/packages/preact-moveable/package-lock.json
@@ -777,9 +777,9 @@
             "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
         },
         "react-moveable": {
-            "version": "0.13.6-rc",
-            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.6-rc.tgz",
-            "integrity": "sha512-exRHKbBrqdvSIRpgjqfOxxvG5CHksiFAP6sE1uOYfQgKBOYc3KuCDtVWHljmPtEy8TeAczZ4OOlKYCuDDi0h6Q==",
+            "version": "0.13.6-rc2",
+            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.6-rc2.tgz",
+            "integrity": "sha512-R25Lfb6ZS2TFR60LP+ao4fJu9gHY8FTGUHbHB06rvh/WhJJzpjEuPs4jsFw9qKQzqHbgKhQWgFWMZKhitf/NLw==",
             "requires": {
                 "@daybrush/drag": "^0.11.0",
                 "@daybrush/utils": "^0.10.0",

--- a/packages/preact-moveable/package-lock.json
+++ b/packages/preact-moveable/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.5-rc2",
+    "version": "0.12.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -777,9 +777,9 @@
             "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
         },
         "react-moveable": {
-            "version": "0.13.6-rc2",
-            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.6-rc2.tgz",
-            "integrity": "sha512-R25Lfb6ZS2TFR60LP+ao4fJu9gHY8FTGUHbHB06rvh/WhJJzpjEuPs4jsFw9qKQzqHbgKhQWgFWMZKhitf/NLw==",
+            "version": "0.13.6",
+            "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.13.6.tgz",
+            "integrity": "sha512-0QsO8/H8ueRN25yo83iFPiiKaF/WZgmzudOokcR0w1LkmErkLnpDqW3V7cXXH8JXdlOkMmWEm6Cgg3DT9N5mqw==",
             "requires": {
                 "@daybrush/drag": "^0.11.0",
                 "@daybrush/utils": "^0.10.0",

--- a/packages/preact-moveable/package.json
+++ b/packages/preact-moveable/package.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.11.14",
+    "version": "0.12.1",
     "description": "A Preact Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Pinchable, Groupable, Snappable.",
     "main": "./dist/moveable.cjs.js",
     "module": "./dist/moveable.esm.js",
@@ -60,13 +60,8 @@
         "typescript": "^3.4.5"
     },
     "dependencies": {
-        "@daybrush/drag": "^0.10.2",
-        "@daybrush/utils": "^0.10.1",
-        "@egjs/agent": "^2.1.5",
-        "@egjs/children-differ": "^1.0.0",
-        "framework-utils": "^0.2.1",
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.12.14"
+        "react-moveable": "^0.13.2"
     }
 }

--- a/packages/preact-moveable/package.json
+++ b/packages/preact-moveable/package.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.5-rc2",
+    "version": "0.12.5-rc3",
     "description": "A Preact Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Pinchable, Groupable, Snappable.",
     "main": "./dist/moveable.cjs.js",
     "module": "./dist/moveable.esm.js",
@@ -62,6 +62,6 @@
     "dependencies": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.6-rc"
+        "react-moveable": "^0.13.6-rc2"
     }
 }

--- a/packages/preact-moveable/package.json
+++ b/packages/preact-moveable/package.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.5-rc",
+    "version": "0.12.5-rc2",
     "description": "A Preact Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Pinchable, Groupable, Snappable.",
     "main": "./dist/moveable.cjs.js",
     "module": "./dist/moveable.esm.js",

--- a/packages/preact-moveable/package.json
+++ b/packages/preact-moveable/package.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.3",
+    "version": "0.12.4",
     "description": "A Preact Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Pinchable, Groupable, Snappable.",
     "main": "./dist/moveable.cjs.js",
     "module": "./dist/moveable.esm.js",
@@ -62,6 +62,6 @@
     "dependencies": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.4"
+        "react-moveable": "^0.13.5"
     }
 }

--- a/packages/preact-moveable/package.json
+++ b/packages/preact-moveable/package.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.5-rc3",
+    "version": "0.12.6",
     "description": "A Preact Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Pinchable, Groupable, Snappable.",
     "main": "./dist/moveable.cjs.js",
     "module": "./dist/moveable.esm.js",
@@ -62,6 +62,6 @@
     "dependencies": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.6-rc2"
+        "react-moveable": "^0.13.6"
     }
 }

--- a/packages/preact-moveable/package.json
+++ b/packages/preact-moveable/package.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.4",
+    "version": "0.12.5-rc",
     "description": "A Preact Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Pinchable, Groupable, Snappable.",
     "main": "./dist/moveable.cjs.js",
     "module": "./dist/moveable.esm.js",
@@ -62,6 +62,6 @@
     "dependencies": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.5"
+        "react-moveable": "^0.13.6-rc"
     }
 }

--- a/packages/preact-moveable/package.json
+++ b/packages/preact-moveable/package.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "description": "A Preact Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Pinchable, Groupable, Snappable.",
     "main": "./dist/moveable.cjs.js",
     "module": "./dist/moveable.esm.js",
@@ -62,6 +62,6 @@
     "dependencies": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.2"
+        "react-moveable": "^0.13.3"
     }
 }

--- a/packages/preact-moveable/package.json
+++ b/packages/preact-moveable/package.json
@@ -1,6 +1,6 @@
 {
     "name": "preact-moveable",
-    "version": "0.12.2",
+    "version": "0.12.3",
     "description": "A Preact Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Pinchable, Groupable, Snappable.",
     "main": "./dist/moveable.cjs.js",
     "module": "./dist/moveable.esm.js",
@@ -62,6 +62,6 @@
     "dependencies": {
         "preact-compat": "^3.0.0",
         "preact-css-styler": "^0.4.1",
-        "react-moveable": "^0.13.3"
+        "react-moveable": "^0.13.4"
     }
 }

--- a/packages/preact-moveable/rollup.config.js
+++ b/packages/preact-moveable/rollup.config.js
@@ -6,10 +6,9 @@ const defaultOptions = {
     tsconfig: "tsconfig.build.json",
     external: {
         "@daybrush/utils": "utils",
-        "@daybrush/drag": "utils",
+        "@daybrush/drag": "Dragger",
         "preact": "Preact",
         "preact-compat": "preact-compat",
-        // "preact/compat": "preact/compat",
         "framework-utils": "framework-utils",
         "preact-css-styler": "preact-css-styler",
         "@egjs/agent": "eg.Agent",

--- a/packages/preact-moveable/src/preact-moveable/types.ts
+++ b/packages/preact-moveable/src/preact-moveable/types.ts
@@ -1,11 +1,6 @@
 import { MoveableProps, MoveableState, MoveableInterface } from "react-moveable/declaration/types";
 import { Component } from "preact";
 
-export interface PreactMoveableInterface extends Component<MoveableProps, MoveableState>, MoveableInterface {
-    isMoveableElement(target: HTMLElement | SVGElement): boolean;
-    updateRect(isNotSetState?: boolean): void;
-    updateTarget(): void;
-    destroy(): void;
-    dragStart(e: MouseEvent | TouchEvent): void;
-    isInside(clientX: number, clientY: number): boolean;
-}
+export type PreactMoveableInterface = {
+    [key in Exclude<keyof MoveableInterface, "setState">]: MoveableInterface[key]
+} & Component<MoveableProps, MoveableState>;

--- a/packages/react-moveable/package-lock.json
+++ b/packages/react-moveable/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-moveable",
-  "version": "0.12.14",
+  "version": "0.13.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-moveable/package.json
+++ b/packages/react-moveable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-moveable",
-  "version": "0.13.5",
+  "version": "0.13.6-rc",
   "description": "A React Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",

--- a/packages/react-moveable/package.json
+++ b/packages/react-moveable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-moveable",
-  "version": "0.13.6-rc",
+  "version": "0.13.6-rc2",
   "description": "A React Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",

--- a/packages/react-moveable/package.json
+++ b/packages/react-moveable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-moveable",
-  "version": "0.13.6-rc2",
+  "version": "0.13.6",
   "description": "A React Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",

--- a/packages/react-moveable/package.json
+++ b/packages/react-moveable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-moveable",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "A React Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",

--- a/packages/react-moveable/package.json
+++ b/packages/react-moveable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-moveable",
-  "version": "0.13.0",
+  "version": "0.13.2",
   "description": "A React Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",

--- a/packages/react-moveable/package.json
+++ b/packages/react-moveable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-moveable",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "A React Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",

--- a/packages/react-moveable/package.json
+++ b/packages/react-moveable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-moveable",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "A React Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable.",
   "main": "./dist/moveable.cjs.js",
   "module": "./dist/moveable.esm.js",

--- a/packages/react-moveable/src/react-moveable/MoveableGroup.tsx
+++ b/packages/react-moveable/src/react-moveable/MoveableGroup.tsx
@@ -128,7 +128,7 @@ class MoveableGroup extends MoveableManager<GroupableProps, any> {
         this.updateAbles();
     }
 
-    public updateRect(type?: "Start" | "" | "End", isTarget?: boolean) {
+    public updateRect(type?: "Start" | "" | "End", isTarget?: boolean, isSetState: boolean = true) {
         if (!this.controlBox) {
             return;
         }
@@ -168,7 +168,7 @@ class MoveableGroup extends MoveableManager<GroupableProps, any> {
                 left: left - info.left!,
                 top: top - info.top!,
             },
-            true,
+            isSetState,
         );
     }
     public triggerEvent(name: string, e: any): any {

--- a/packages/react-moveable/src/react-moveable/MoveableGroup.tsx
+++ b/packages/react-moveable/src/react-moveable/MoveableGroup.tsx
@@ -148,7 +148,6 @@ class MoveableGroup extends MoveableManager<GroupableProps, any> {
 
         // tslint:disable-next-line: max-line-length
         target.style.cssText += `left:0px;top:0px;width:${width}px; height:${height}px;transform:rotate(${rotation}deg)`;
-
         state.width = width;
         state.height = height;
 

--- a/packages/react-moveable/src/react-moveable/ables/DragArea.tsx
+++ b/packages/react-moveable/src/react-moveable/ables/DragArea.tsx
@@ -3,7 +3,7 @@ import { createWarpMatrix, convertMatrixtoCSS } from "@moveable/matrix";
 import { ref } from "framework-utils";
 import { triggerEvent, fillParams } from "../utils";
 import { Renderer, GroupableProps, DragAreaProps, OnClick } from "../types";
-import { AREA_PIECE, AREA, AVOID } from "../classNames";
+import { AREA_PIECE, AREA, AVOID, AREA_PIECES } from "../classNames";
 import MoveableGroup from "../MoveableGroup";
 import { addClass, findIndex, removeClass } from "@daybrush/utils";
 
@@ -16,6 +16,14 @@ function restoreStyle(moveable: MoveableManager) {
     el.style.cssText += `left: 0px; top: 0px; width: ${width}px; height: ${height}px`;
 }
 
+function renderPieces(React: Renderer): any {
+    return (<div key="area_pieces" className={AREA_PIECES}>
+        <div className={AREA_PIECE}></div>
+        <div className={AREA_PIECE}></div>
+        <div className={AREA_PIECE}></div>
+        <div className={AREA_PIECE}></div>
+    </div>);
+}
 export default {
     name: "dragArea",
     render(moveable: MoveableManager<GroupableProps>, React: Renderer): any[] {
@@ -25,12 +33,8 @@ export default {
 
         if (groupable) {
             return [
-                <div key="area" ref={ref(moveable, "areaElement")} className={AREA}>
-                    <div className={AREA_PIECE}></div>
-                    <div className={AREA_PIECE}></div>
-                    <div className={AREA_PIECE}></div>
-                    <div className={AREA_PIECE}></div>
-                </div>,
+                <div key="area" ref={ref(moveable, "areaElement")} className={AREA}></div>,
+                renderPieces(React),
             ];
         }
         if (!target || !dragArea) {
@@ -56,18 +60,14 @@ export default {
                 height: `${height}px`,
                 transformOrigin: "0 0",
                 transform,
-            }}>
-                <div className={AREA_PIECE}></div>
-                <div className={AREA_PIECE}></div>
-                <div className={AREA_PIECE}></div>
-                <div className={AREA_PIECE}></div>
-            </div>,
+            }}></div>,
+            renderPieces(React),
         ];
     },
     dragStart(moveable: MoveableManager, { datas, clientX, clientY }: any) {
         datas.isDrag = false;
         const areaElement = moveable.areaElement;
-        const { left, top, width, height } = moveable.state.target!.getBoundingClientRect();
+        const { left, top, width, height } = moveable.state.clientRect;
         const posX = clientX - left;
         const posY = clientY - top;
         const rects = [
@@ -77,7 +77,7 @@ export default {
             { left: posX + 10, top: 0, width: width - posX - 10, height },
         ];
 
-        const children = [].slice.call(areaElement.children) as HTMLElement[];
+        const children = [].slice.call(areaElement.nextElementSibling!.children) as HTMLElement[];
         rects.forEach((rect, i) => {
             children[i].style.cssText
                 = `left: ${rect.left}px;top: ${rect.top}px; width: ${rect.width}px; height: ${rect.height}px;`;

--- a/packages/react-moveable/src/react-moveable/ables/DragArea.tsx
+++ b/packages/react-moveable/src/react-moveable/ables/DragArea.tsx
@@ -64,8 +64,9 @@ export default {
             renderPieces(React),
         ];
     },
-    dragStart(moveable: MoveableManager, { datas, clientX, clientY }: any) {
-        datas.isDrag = false;
+    dragStart(moveable: MoveableManager, { datas, clientX, clientY, inputEvent }: any) {
+        datas.isDragArea = false;
+        datas.inputTarget = inputEvent.target;
         const areaElement = moveable.areaElement;
         const { left, top, width, height } = moveable.state.clientRect;
         const posX = clientX - left;
@@ -85,21 +86,21 @@ export default {
         addClass(areaElement, AVOID);
     },
     drag(moveable: MoveableManager, { datas }: any) {
-        if (!datas.isDrag) {
-            datas.isDrag = true;
+        if (!datas.isDragArea) {
+            datas.isDragArea = true;
             restoreStyle(moveable);
         }
     },
     dragEnd(moveable: MoveableManager<DragAreaProps>, e: any) {
-        const { inputEvent, isDrag, datas } = e;
-        if (!datas.isDrag) {
+        const { inputEvent, isDragArea, datas } = e;
+        if (!datas.isDragArea) {
             restoreStyle(moveable);
         }
 
         const target = moveable.state.target!;
         const inputTarget = inputEvent.target;
 
-        if (isDrag || moveable.isMoveableElement(inputTarget)) {
+        if (isDragArea || moveable.isMoveableElement(inputTarget)) {
             return;
         }
         const containsTarget = target.contains(inputTarget);
@@ -120,14 +121,15 @@ export default {
         moveable: MoveableGroup,
         e: any,
     ) {
-        const { inputEvent, isDrag, datas } = e;
-        if (!datas.isDrag) {
+        const { inputEvent, isDragArea, datas } = e;
+
+        if (!isDragArea) {
             restoreStyle(moveable);
         }
-
+        const prevInputTarget = datas.inputTarget;
         const inputTarget = inputEvent.target;
 
-        if (isDrag || moveable.isMoveableElement(inputTarget)) {
+        if (isDragArea || moveable.isMoveableElement(inputTarget) || prevInputTarget === inputTarget) {
             return;
         }
         const targets = moveable.props.targets!;

--- a/packages/react-moveable/src/react-moveable/ables/Draggable.ts
+++ b/packages/react-moveable/src/react-moveable/ables/Draggable.ts
@@ -142,9 +142,6 @@ export default {
         }));
         return isDrag;
     },
-    dragGroupCondition(target: HTMLElement | SVGElement) {
-        return hasClass(target, AREA);
-    },
     dragGroupStart(moveable: MoveableGroup, e: any) {
         const datas = e.datas;
 

--- a/packages/react-moveable/src/react-moveable/ables/triggerRender.ts
+++ b/packages/react-moveable/src/react-moveable/ables/triggerRender.ts
@@ -4,42 +4,49 @@ import { IObject } from "@daybrush/utils";
 
 export function triggerRenderStart(
     moveable: MoveableManager<any>,
-    eventAffix: string,
+    isGroup: boolean,
     e: any,
 ) {
     const params: IObject<any> = fillParams(moveable, e, {
         isPinch: !!e.isPinch,
     });
 
-    if (eventAffix === "Group") {
+    const eventAffix = isGroup ? "Group" : "";
+
+    if (isGroup) {
         params.targets = moveable.props.targets;
     }
     triggerEvent(moveable, `onRender${eventAffix}Start`, params);
 }
 export function triggerRender(
     moveable: MoveableManager<any>,
-    eventAffix: string,
+    isGroup: boolean,
     e: any,
 ) {
     const params: IObject<any> = fillParams(moveable, e, {
         isPinch: !!e.isPinch,
     });
 
-    if (eventAffix === "Group") {
+    const eventAffix = isGroup ? "Group" : "";
+
+    if (isGroup) {
         params.targets = moveable.props.targets;
     }
     triggerEvent(moveable, `onRender${eventAffix}`, params);
 }
 export function triggerRenderEnd(
     moveable: MoveableManager<any>,
-    eventAffix: string,
+    isGroup: boolean,
     e: any,
 ) {
     const params: IObject<any> = fillParams(moveable, e, {
         isPinch: !!e.sPinch,
+        isDrag: e.isDrag,
     });
 
-    if (eventAffix === "Group") {
+    const eventAffix = isGroup ? "Group" : "";
+
+    if (isGroup) {
         params.targets = moveable.props.targets;
     }
     triggerEvent(moveable, `onRender${eventAffix}End`, params);

--- a/packages/react-moveable/src/react-moveable/classNames.ts
+++ b/packages/react-moveable/src/react-moveable/classNames.ts
@@ -1,5 +1,6 @@
 import { prefix } from "./utils";
 
 export const AREA = prefix("area");
+export const AREA_PIECES = prefix("area-pieces");
 export const AREA_PIECE = prefix("area-piece");
 export const AVOID = prefix("avoid");

--- a/packages/react-moveable/src/react-moveable/consts.ts
+++ b/packages/react-moveable/src/react-moveable/consts.ts
@@ -86,17 +86,20 @@ export const MOVEABLE_CSS = prefixCSS(PREFIX, `
 .area {
     position: absolute;
 }
+.area-pieces {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: none;
+}
 .area.avoid {
-    transform: none!important;
-    width: 0px!important;
-    height: 0px!important;
+    pointer-events: none;
+}
+.area.avoid+.area-pieces {
+    display: block;
 }
 .area-piece {
     position: absolute;
-    display: none;
-}
-.area.avoid .area-piece {
-    display: block;
 }
 ${isWebkit ? `:global svg *:before {
 	content:"";

--- a/packages/react-moveable/src/react-moveable/getAbleDragger.ts
+++ b/packages/react-moveable/src/react-moveable/getAbleDragger.ts
@@ -12,13 +12,13 @@ function triggerAble<T extends IObject<any>>(
     eventType: any,
     e: OnDragStart | OnDrag | OnDragEnd | OnPinchEnd,
 ) {
-    if (eventAffix.indexOf("Control") > -1 && moveable.areaElement === e.inputEvent.target) {
+    const isStart = eventType === "Start";
+
+    if (isStart && eventAffix.indexOf("Control") > -1 && moveable.areaElement === e.inputEvent.target) {
         return false;
     }
     const eventName = `${eventOperation}${eventAffix}${eventType}`;
     const conditionName = `${eventOperation}${eventAffix}Condition`;
-
-    const isStart = eventType === "Start";
     const isEnd = eventType === "End";
 
     if (isStart) {

--- a/packages/react-moveable/src/react-moveable/getAbleDragger.ts
+++ b/packages/react-moveable/src/react-moveable/getAbleDragger.ts
@@ -19,7 +19,7 @@ function triggerAble<T extends IObject<any>>(
     const isEnd = eventType === "End";
 
     if (isStart) {
-        moveable.updateTarget(eventType);
+        moveable.updateRect(eventType, true, false);
     }
     const isGroup = eventAffix.indexOf("Group") > -1;
     const ables: Array<Able<T>> = (moveable as any)[ableType];

--- a/packages/react-moveable/src/react-moveable/getAbleDragger.ts
+++ b/packages/react-moveable/src/react-moveable/getAbleDragger.ts
@@ -12,6 +12,9 @@ function triggerAble<T extends IObject<any>>(
     eventType: any,
     e: OnDragStart | OnDrag | OnDragEnd | OnPinchEnd,
 ) {
+    if (eventAffix.indexOf("Control") > -1 && moveable.areaElement === e.inputEvent.target) {
+        return false;
+    }
     const eventName = `${eventOperation}${eventAffix}${eventType}`;
     const conditionName = `${eventOperation}${eventAffix}Condition`;
 
@@ -34,11 +37,11 @@ function triggerAble<T extends IObject<any>>(
     const isUpdate = results.length;
 
     if (isStart) {
-        triggerRenderStart(moveable, eventAffix, e);
+        triggerRenderStart(moveable, isGroup, e);
     } else if (isEnd) {
-        triggerRenderEnd(moveable, eventAffix, e);
+        triggerRenderEnd(moveable, isGroup, e);
     } else {
-        triggerRender(moveable, eventAffix, e);
+        triggerRender(moveable, isGroup, e);
     }
     if (isEnd) {
         moveable.state.dragger = null;
@@ -58,7 +61,6 @@ export function getAbleDragger<T>(
     target: HTMLElement | SVGElement,
     ableType: string,
     eventAffix: string,
-
 ) {
     const options: IObject<any> = {
         container: window,

--- a/packages/react-moveable/src/react-moveable/types.ts
+++ b/packages/react-moveable/src/react-moveable/types.ts
@@ -2,7 +2,6 @@ import { IObject } from "@daybrush/utils";
 import Dragger, * as DraggerTypes from "@daybrush/drag";
 import CustomDragger from "./CustomDragger";
 import { Position } from "@daybrush/drag";
-import MoveableManager from "./MoveableManager";
 
 export interface MoveableClientRect {
     left: number;
@@ -147,7 +146,7 @@ export interface Able<T = any> {
  * @property - The mouse or touch input event that is invoking the moveable event
  */
 export interface OnEvent {
-    currentTarget: MoveableManager;
+    currentTarget: MoveableInterface;
     target: HTMLElement | SVGElement;
     clientX: number;
     clientY: number;
@@ -823,6 +822,18 @@ export interface OnCustomDrag extends Position {
     parentDragger: CustomDragger;
 }
 
+/**
+ * @typedef
+ * @memberof Moveable
+ * @property - The coordinates of the vertex 1
+ * @property - The coordinates of the vertex 1
+ * @property - The coordinates of the vertex 1
+ * @property - The coordinates of the vertex 1
+ * @property - left position of the target relative to the container
+ * @property - top position of the target relative to the container
+ * @property - the offset width of the target
+ * @property - the offset height of the target
+ */
 export interface RectInfo {
     pos1: number[];
     pos2: number[];
@@ -841,5 +852,5 @@ export interface MoveableInterface {
     destroy(): void;
     dragStart(e: MouseEvent | TouchEvent): void;
     isInside(clientX: number, clientY: number): boolean;
-    setState(state: IObject<any>, callback: () => any): void;
+    setState(state: any, callback?: () => any): any;
 }

--- a/src/InnerMoveable.tsx
+++ b/src/InnerMoveable.tsx
@@ -1,4 +1,5 @@
 import { Component, h } from "preact";
+import { createPortal } from "preact/compat";
 import Moveable, { MoveableProps, PreactMoveableInterface } from "preact-moveable";
 import { ref } from "framework-utils";
 
@@ -10,6 +11,6 @@ export default class InnerMoveable extends Component<MoveableProps> {
         this.state = this.props;
     }
     public render() {
-        return <Moveable ref={ref(this, "preactMoveable")} {...this.state} />;
+        return createPortal(<Moveable ref={ref(this, "preactMoveable")} {...this.state} />, this.props.parentElement);
     }
 }

--- a/src/Moveable.tsx
+++ b/src/Moveable.tsx
@@ -49,13 +49,13 @@ import { camelize, isArray } from "@daybrush/utils";
 })
 class Moveable extends EgComponent implements MoveableInterface {
     private innerMoveable!: InnerMoveable;
+    private tempElement = document.createElement("div");
 
     /**
      *
      */
     constructor(parentElement: HTMLElement | SVGElement, options: MoveableOptions = {}) {
         super();
-        const element = document.createElement("div");
         const nextOptions = { container: parentElement, ...options };
 
         const events: any = {};
@@ -67,13 +67,12 @@ class Moveable extends EgComponent implements MoveableInterface {
         render(
             <InnerMoveable
                 ref={ref(this, "innerMoveable")}
+                parentElement={parentElement}
                 {...nextOptions}
                 {...events}
             />,
-            element,
+            this.tempElement,
         );
-        parentElement.appendChild(element.children[0]);
-
         const target = nextOptions.target!;
         if (isArray(target) && target.length > 1) {
             this.updateRect();
@@ -201,11 +200,9 @@ class Moveable extends EgComponent implements MoveableInterface {
      * moveable.destroy();
      */
     public destroy() {
-        const el = this.getMoveable().base;
-
-        el.remove ? el.remove() : el.parentElement.removeChild(el);
+        render("", this.tempElement);
         this.off();
-        this.getMoveable().destroy();
+        this.tempElement = null;
         this.innerMoveable = null;
     }
     private getMoveable() {

--- a/src/Moveable.tsx
+++ b/src/Moveable.tsx
@@ -532,7 +532,6 @@ class Moveable extends EgComponent implements MoveableInterface {
  *
  */
 
-
 /**
  * When the drag starts, the dragStart event is called.
  * @memberof Moveable
@@ -572,6 +571,66 @@ class Moveable extends EgComponent implements MoveableInterface {
  *     console.log(target, isDrag);
  * });
  */
+
+ /**
+ * When the group drag starts, the `dragGroupStart` event is called.
+ * @memberof Moveable
+ * @event dragGroupStart
+ * @param {Moveable.OnDragGroupStart} - Parameters for the `dragGroupStart` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: [].slice.call(document.querySelectorAll(".target")),
+ *     draggable: true
+ * });
+ * moveable.on("dragGroupStart", ({ targets }) => {
+ *     console.log("onDragGroupStart", targets);
+ * });
+ */
+
+ /**
+ * When the group drag, the `dragGroup` event is called.
+ * @memberof Moveable
+ * @event dragGroup
+ * @param {Moveable.onDragGroup} - Parameters for the `dragGroup` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: [].slice.call(document.querySelectorAll(".target")),
+ *     draggable: true
+ * });
+ * moveable.on("dragGroup", ({ targets, events }) => {
+ *     console.log("onDragGroup", targets);
+ *     events.forEach(ev => {
+ *          // drag event
+ *          console.log("onDrag left, top", ev.left, ev.top);
+ *          // ev.target!.style.left = `${ev.left}px`;
+ *          // ev.target!.style.top = `${ev.top}px`;
+ *          console.log("onDrag translate", ev.dist);
+ *          ev.target!.style.transform = ev.transform;)
+ *     });
+ * });
+ */
+
+/**
+ * When the group drag finishes, the `dragGroupEnd` event is called.
+ * @memberof Moveable
+ * @event dragGroupEnd
+ * @param {Moveable.OnDragGroupEnd} - Parameters for the `dragGroupEnd` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: [].slice.call(document.querySelectorAll(".target")),
+ *     draggable: true
+ * });
+ * moveable.on("dragGroupEnd", ({ targets, isDrag }) => {
+ *     console.log("onDragGroupEnd", targets, isDrag);
+ * });
+ */
+
 /**
  * When the resize starts, the resizeStart event is called.
  * @memberof Moveable
@@ -804,65 +863,6 @@ class Moveable extends EgComponent implements MoveableInterface {
  * });
  * moveable.on("scaleEnd", ({ target }) => {
  *     console.log(target);
- * });
- */
-
- /**
- * When the group drag starts, the `dragGroupStart` event is called.
- * @memberof Moveable
- * @event dragGroupStart
- * @param {Moveable.OnDragGroupStart} - Parameters for the `dragGroupStart` event
- * @example
- * import Moveable from "moveable";
- *
- * const moveable = new Moveable(document.body, {
- *     target: [].slice.call(document.querySelectorAll(".target")),
- *     draggable: true
- * });
- * moveable.on("dragGroupStart", ({ targets }) => {
- *     console.log("onDragGroupStart", targets);
- * });
- */
-
- /**
- * When the group drag, the `dragGroup` event is called.
- * @memberof Moveable
- * @event dragGroup
- * @param {Moveable.onDragGroup} - Parameters for the `dragGroup` event
- * @example
- * import Moveable from "moveable";
- *
- * const moveable = new Moveable(document.body, {
- *     target: [].slice.call(document.querySelectorAll(".target")),
- *     draggable: true
- * });
- * moveable.on("dragGroup", ({ targets, events }) => {
- *     console.log("onDragGroup", targets);
- *     events.forEach(ev => {
- *          // drag event
- *          console.log("onDrag left, top", ev.left, ev.top);
- *          // ev.target!.style.left = `${ev.left}px`;
- *          // ev.target!.style.top = `${ev.top}px`;
- *          console.log("onDrag translate", ev.dist);
- *          ev.target!.style.transform = ev.transform;)
- *     });
- * });
- */
-
-/**
- * When the group drag finishes, the `dragGroupEnd` event is called.
- * @memberof Moveable
- * @event dragGroupEnd
- * @param {Moveable.OnDragGroupEnd} - Parameters for the `dragGroupEnd` event
- * @example
- * import Moveable from "moveable";
- *
- * const moveable = new Moveable(document.body, {
- *     target: [].slice.call(document.querySelectorAll(".target")),
- *     draggable: true
- * });
- * moveable.on("dragGroupEnd", ({ targets, isDrag }) => {
- *     console.log("onDragGroupEnd", targets, isDrag);
  * });
  */
 
@@ -1107,9 +1107,9 @@ class Moveable extends EgComponent implements MoveableInterface {
  * const moveable = new Moveable(document.body, {
  *     target: document.querySelector(".target"),
  * });
- * moveable.on("click", ({ hasTarget, containsTarget, targetIndex }) => {
+ * moveable.on("click", ({ isTarget, containsTarget, targetIndex }) => {
  *     // If you click on an element other than the target and not included in the target, index is -1.
- *     console.log("onClickGroup", target, hasTarget, containsTarget, targetIndex);
+ *     console.log("onClick", target, isTarget, containsTarget, targetIndex);
  * });
  */
 
@@ -1124,13 +1124,11 @@ class Moveable extends EgComponent implements MoveableInterface {
  * const moveable = new Moveable(document.body, {
  *     target: [].slice.call(document.querySelectorAll(".target")),
  * });
- * moveable.on("clickGroup", ({ target, hasTarget, containsTarget, targetIndex }) => {
+ * moveable.on("clickGroup", ({ target, isTarget, containsTarget, targetIndex }) => {
  *     // If you click on an element other than the target and not included in the target, index is -1.
- *     console.log("onClickGroup", target, hasTarget, containsTarget, targetIndex);
+ *     console.log("onClickGroup", target, isTarget, containsTarget, targetIndex);
  * });
  */
-
-
 
 /**
  * `renderStart` event occurs at the first start of all events.
@@ -1180,6 +1178,54 @@ class Moveable extends EgComponent implements MoveableInterface {
  * });
  */
 
+/**
+ * `renderGroupStart` event occurs at the first start of all events in group.
+ * @memberof Moveable
+ * @event renderGroupStart
+ * @param {Moveable.OnRenderGroupStart} - Parameters for the `renderGroupStart` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: [].slice.call(document.querySelectorAll(".target")),
+ * });
+ * moveable.on("renderGroupStart", ({ target }) => {
+ *     console.log("onRenderGroupStart", target);
+ * });
+ */
+
+/**
+ * `renderGroup` event occurs before the target is drawn on the screen in group.
+ * @memberof Moveable
+ * @event renderGroup
+ * @param {Moveable.OnRenderGroup} - Parameters for the `renderGroup` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: [].slice.call(document.querySelectorAll(".target")),
+ * });
+ * moveable.on("renderGroup", ({ target }) => {
+ *     console.log("onRenderGroup", target);
+ * });
+ */
+
+/**
+ * `renderGroupEnd` event occurs at the end of all events in group.
+ * @memberof Moveable
+ * @event renderGroupEnd
+ * @param {Moveable.OnRenderGroupEnd} - Parameters for the `renderGroupEnd` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: [].slice.call(document.querySelectorAll(".target")),
+ * });
+ * moveable.on("renderGroupEnd", ({ target }) => {
+ *     console.log("onRenderGroupEnd", target);
+ * });
+ */
+
 interface Moveable extends MoveableGetterSetter {
     on(eventName: "drag", handlerToAttach: (event: OnDrag) => any): this;
     on(eventName: "dragStart", handlerToAttach: (event: OnDragStart) => any): this;
@@ -1187,7 +1233,6 @@ interface Moveable extends MoveableGetterSetter {
     on(eventName: "dragGroup", handlerToAttach: (event: OnDragGroup) => any): this;
     on(eventName: "dragGroupStart", handlerToAttach: (event: OnDragGroupStart) => any): this;
     on(eventName: "dragGroupEnd", handlerToAttach: (event: OnDragGroupEnd) => any): this;
-
 
     on(eventName: "resize", handlerToAttach: (event: OnResize) => any): this;
     on(eventName: "resizeStart", handlerToAttach: (event: OnResizeStart) => any): this;

--- a/src/Moveable.tsx
+++ b/src/Moveable.tsx
@@ -15,6 +15,15 @@ import {
     OnPinchGroup, OnPinchGroupStart, OnPinchGroupEnd, OnScaleGroupStart, OnClickGroup,
     MoveableInterface,
     RectInfo,
+    OnClick,
+    OnScroll,
+    OnScrollGroup,
+    OnRenderStart,
+    OnRender,
+    OnRenderEnd,
+    OnRenderGroupStart,
+    OnRenderGroup,
+    OnRenderGroupEnd,
 } from "react-moveable/declaration/types";
 import { PROPERTIES, EVENTS } from "./consts";
 import { camelize, isArray } from "@daybrush/utils";
@@ -30,7 +39,7 @@ import { camelize, isArray } from "@daybrush/utils";
             return this.getMoveable().props[property];
         },
         set(value) {
-            this.innerMoveable.setState({
+            this.setState({
                 [property]: value,
             });
         },
@@ -138,8 +147,36 @@ class Moveable extends EgComponent implements MoveableInterface {
     public isInside(clientX: number, clientY: number): boolean {
         return this.getMoveable().isInside(clientX, clientY);
     }
+    /**
+     * You can get the vertex information, position and offset size information of the target based on the container.
+     * @return - The Rect Info
+     * @example
+     * import Moveable from "moveable";
+     *
+     * const moveable = new Moveable(document.body);
+     *
+     * const rectInfo = moveable.getRect();
+     */
     public getRect(): RectInfo {
         return this.getMoveable().getRect();
+    }
+    /**
+     * You can change options or properties dynamically.
+     * @param - options or properties
+     * @param - After the change, the callback function is executed when the update is completed.
+     * @example
+     * import Moveable from "moveable";
+     *
+     * const moveable = new Moveable(document.body);
+     *
+     * moveable.setState({
+     *   target: document.querySelector(".target"),
+     * }, () => {
+     *   moveable.dragStart(e);
+     * })
+     */
+    public setState(state: Partial<MoveableOptions>, callback?: () => any) {
+        this.innerMoveable.setState(state, callback);
     }
     /**
      * If the width, height, left, and top of the only target change, update the shape of the moveable.
@@ -412,6 +449,89 @@ class Moveable extends EgComponent implements MoveableInterface {
  *
  * moveable.rotationPosition = "bottom"
  */
+/**
+ * You can specify the className of the moveable controlbox. (default: "")
+ * @name Moveable#className
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *   className: "",
+ * });
+ *
+ * moveable.className = "moveable1";
+ */
+/**
+ * Set directions to show the control box. (default: ["n", "nw", "ne", "s", "se", "sw", "e", "w"])
+ * @name Moveable#renderDirections
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *   renderDirections: ["n", "nw", "ne", "s", "se", "sw", "e", "w"],
+ * });
+ *
+ * moveable.renderDirections = ["nw", "ne", "sw", "se"];
+ */
+
+/**
+ * Whether or not target can be scrolled to the scroll container (default: false)
+ * @name Moveable#scrollable
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *   scrollable: true,
+ *   scrollContainer: document.body,
+ *   scrollThreshold: 0,
+ *   getScrollPosition: ({ scrollContainer }) => ([scrollContainer.scrollLeft, scrollContainer.scrollTop]),
+ * });
+ *
+ * moveable.scrollable = true;
+ */
+
+/**
+ * The container to which scroll is applied (default: container)
+ * @name Moveable#scrollContainer
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *   scrollable: true,
+ *   scrollContainer: document.body,
+ *   scrollThreshold: 0,
+ *   getScrollPosition: ({ scrollContainer }) => ([scrollContainer.scrollLeft, scrollContainer.scrollTop]),
+ * });
+ */
+/**
+ * Expand the range of the scroll check area. (default: 0)
+ * @name Moveable#scrollThreshold
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *   scrollable: true,
+ *   scrollContainer: document.body,
+ *   scrollThreshold: 0,
+ *   getScrollPosition: ({ scrollContainer }) => ([scrollContainer.scrollLeft, scrollContainer.scrollTop]),
+ * });
+ */
+
+/**
+ * Sets a function to get the scroll position. (default: Function)
+ * @name Moveable#getScrollPosition
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *   scrollable: true,
+ *   scrollContainer: document.body,
+ *   scrollThreshold: 0,
+ *   getScrollPosition: ({ scrollContainer }) => ([scrollContainer.scrollLeft, scrollContainer.scrollTop]),
+ * });
+ *
+ */
+
 
 /**
  * When the drag starts, the dragStart event is called.
@@ -942,7 +1062,7 @@ class Moveable extends EgComponent implements MoveableInterface {
  * });
  */
 
- /**
+/**
  * When the group pinch, the `pinchGroup` event is called.
  * @memberof Moveable
  * @event pinchGroup
@@ -976,7 +1096,24 @@ class Moveable extends EgComponent implements MoveableInterface {
  * });
  */
 
- /**
+/**
+ * When you click on the element, the `click` event is called.
+ * @memberof Moveable
+ * @event click
+ * @param {Moveable.OnClick} - Parameters for the `click` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: document.querySelector(".target"),
+ * });
+ * moveable.on("click", ({ hasTarget, containsTarget, targetIndex }) => {
+ *     // If you click on an element other than the target and not included in the target, index is -1.
+ *     console.log("onClickGroup", target, hasTarget, containsTarget, targetIndex);
+ * });
+ */
+
+/**
  * When you click on the element inside the group, the `clickGroup` event is called.
  * @memberof Moveable
  * @event clickGroup
@@ -993,22 +1130,85 @@ class Moveable extends EgComponent implements MoveableInterface {
  * });
  */
 
+
+
+/**
+ * `renderStart` event occurs at the first start of all events.
+ * @memberof Moveable
+ * @event renderStart
+ * @param {Moveable.OnRenderStart} - Parameters for the `renderStart` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: document.querySelector(".target"),
+ * });
+ * moveable.on("renderStart", ({ target }) => {
+ *     console.log("onRenderStart", target);
+ * });
+ */
+
+/**
+ * `render` event occurs before the target is drawn on the screen.
+ * @memberof Moveable
+ * @event render
+ * @param {Moveable.OnRender} - Parameters for the `render` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: document.querySelector(".target"),
+ * });
+ * moveable.on("render", ({ target }) => {
+ *     console.log("onRender", target);
+ * });
+ */
+
+/**
+ * `renderEnd` event occurs at the end of all events.
+ * @memberof Moveable
+ * @event renderEnd
+ * @param {Moveable.OnRenderEnd} - Parameters for the `renderEnd` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: document.querySelector(".target"),
+ * });
+ * moveable.on("renderEnd", ({ target }) => {
+ *     console.log("onRenderEnd", target);
+ * });
+ */
+
 interface Moveable extends MoveableGetterSetter {
     on(eventName: "drag", handlerToAttach: (event: OnDrag) => any): this;
     on(eventName: "dragStart", handlerToAttach: (event: OnDragStart) => any): this;
     on(eventName: "dragEnd", handlerToAttach: (event: OnDragEnd) => any): this;
+    on(eventName: "dragGroup", handlerToAttach: (event: OnDragGroup) => any): this;
+    on(eventName: "dragGroupStart", handlerToAttach: (event: OnDragGroupStart) => any): this;
+    on(eventName: "dragGroupEnd", handlerToAttach: (event: OnDragGroupEnd) => any): this;
+
 
     on(eventName: "resize", handlerToAttach: (event: OnResize) => any): this;
     on(eventName: "resizeStart", handlerToAttach: (event: OnResizeStart) => any): this;
     on(eventName: "resizeEnd", handlerToAttach: (event: OnResizeEnd) => any): this;
+    on(eventName: "resizeGroup", handlerToAttach: (event: OnResizeGroup) => any): this;
+    on(eventName: "resizeGroupStart", handlerToAttach: (event: OnResizeGroupStart) => any): this;
+    on(eventName: "resizeGroupEnd", handlerToAttach: (event: OnResizeGroupEnd) => any): this;
 
     on(eventName: "scale", handlerToAttach: (event: OnScale) => any): this;
     on(eventName: "scaleStart", handlerToAttach: (event: OnScaleStart) => any): this;
     on(eventName: "scaleEnd", handlerToAttach: (event: OnScaleEnd) => any): this;
+    on(eventName: "scaleGroup", handlerToAttach: (event: OnScaleGroup) => any): this;
+    on(eventName: "scaleGroupStart", handlerToAttach: (event: OnScaleGroupStart) => any): this;
+    on(eventName: "scaleGroupEnd", handlerToAttach: (event: OnScaleGroupEnd) => any): this;
 
     on(eventName: "rotate", handlerToAttach: (event: OnRotate) => any): this;
     on(eventName: "rotateStart", handlerToAttach: (event: OnRotateStart) => any): this;
     on(eventName: "rotateEnd", handlerToAttach: (event: OnRotateEnd) => any): this;
+    on(eventName: "rotateGroup", handlerToAttach: (event: OnRotateGroup) => any): this;
+    on(eventName: "rotateGroupStart", handlerToAttach: (event: OnRotateGroupStart) => any): this;
+    on(eventName: "rotateGroupEnd", handlerToAttach: (event: OnRotateGroupEnd) => any): this;
 
     on(eventName: "warp", handlerToAttach: (event: OnWarp) => any): this;
     on(eventName: "warpStart", handlerToAttach: (event: OnWarpStart) => any): this;
@@ -1017,28 +1217,22 @@ interface Moveable extends MoveableGetterSetter {
     on(eventName: "pinch", handlerToAttach: (event: OnPinch) => any): this;
     on(eventName: "pinchStart", handlerToAttach: (event: OnPinchStart) => any): this;
     on(eventName: "pinchEnd", handlerToAttach: (event: OnPinchEnd) => any): this;
-
-    on(eventName: "dragGroup", handlerToAttach: (event: OnDragGroup) => any): this;
-    on(eventName: "dragGroupStart", handlerToAttach: (event: OnDragGroupStart) => any): this;
-    on(eventName: "dragGroupEnd", handlerToAttach: (event: OnDragGroupEnd) => any): this;
-
-    on(eventName: "resizeGroup", handlerToAttach: (event: OnResizeGroup) => any): this;
-    on(eventName: "resizeGroupStart", handlerToAttach: (event: OnResizeGroupStart) => any): this;
-    on(eventName: "resizeGroupEnd", handlerToAttach: (event: OnResizeGroupEnd) => any): this;
-
-    on(eventName: "scaleGroup", handlerToAttach: (event: OnScaleGroup) => any): this;
-    on(eventName: "scaleGroupStart", handlerToAttach: (event: OnScaleGroupStart) => any): this;
-    on(eventName: "scaleGroupEnd", handlerToAttach: (event: OnScaleGroupEnd) => any): this;
-
-    on(eventName: "rotateGroup", handlerToAttach: (event: OnRotateGroup) => any): this;
-    on(eventName: "rotateGroupStart", handlerToAttach: (event: OnRotateGroupStart) => any): this;
-    on(eventName: "rotateGroupEnd", handlerToAttach: (event: OnRotateGroupEnd) => any): this;
-
     on(eventName: "pinchGroup", handlerToAttach: (event: OnPinchGroup) => any): this;
     on(eventName: "pinchGroupStart", handlerToAttach: (event: OnPinchGroupStart) => any): this;
     on(eventName: "pinchGroupEnd", handlerToAttach: (event: OnPinchGroupEnd) => any): this;
 
+    on(eventName: "click", handlerToAttach: (event: OnClick) => any): this;
     on(eventName: "clickGroup", handlerToAttach: (event: OnClickGroup) => any): this;
+
+    on(eventName: "scroll", handlerToAttach: (event: OnScroll) => any): this;
+    on(eventName: "scrollGroup", handlerToAttach: (event: OnScrollGroup) => any): this;
+
+    on(eventName: "renderStart", handlerToAttach: (event: OnRenderStart) => any): this;
+    on(eventName: "render", handlerToAttach: (event: OnRender) => any): this;
+    on(eventName: "renderEnd", handlerToAttach: (event: OnRenderEnd) => any): this;
+    on(eventName: "renderGroupStart", handlerToAttach: (event: OnRenderGroupStart) => any): this;
+    on(eventName: "renderGroup", handlerToAttach: (event: OnRenderGroup) => any): this;
+    on(eventName: "renderGroupEnd", handlerToAttach: (event: OnRenderGroupEnd) => any): this;
 
     on(eventName: string, handlerToAttach: (event: { [key: string]: any }) => any): this;
     on(events: { [key: string]: (event: { [key: string]: any }) => any }): this;

--- a/src/Moveable.tsx
+++ b/src/Moveable.tsx
@@ -1107,9 +1107,9 @@ class Moveable extends EgComponent implements MoveableInterface {
  * const moveable = new Moveable(document.body, {
  *     target: document.querySelector(".target"),
  * });
- * moveable.on("click", ({ isTarget, containsTarget, targetIndex }) => {
+ * moveable.on("click", ({ hasTarget, containsTarget, targetIndex }) => {
  *     // If you click on an element other than the target and not included in the target, index is -1.
- *     console.log("onClick", target, isTarget, containsTarget, targetIndex);
+ *     console.log("onClickGroup", target, hasTarget, containsTarget, targetIndex);
  * });
  */
 
@@ -1124,9 +1124,9 @@ class Moveable extends EgComponent implements MoveableInterface {
  * const moveable = new Moveable(document.body, {
  *     target: [].slice.call(document.querySelectorAll(".target")),
  * });
- * moveable.on("clickGroup", ({ target, isTarget, containsTarget, targetIndex }) => {
+ * moveable.on("clickGroup", ({ inputTarget, isTarget, containsTarget, targetIndex }) => {
  *     // If you click on an element other than the target and not included in the target, index is -1.
- *     console.log("onClickGroup", target, isTarget, containsTarget, targetIndex);
+ *     console.log("onClickGroup", inputTarget, isTarget, containsTarget, targetIndex);
  * });
  */
 
@@ -1189,8 +1189,8 @@ class Moveable extends EgComponent implements MoveableInterface {
  * const moveable = new Moveable(document.body, {
  *     target: [].slice.call(document.querySelectorAll(".target")),
  * });
- * moveable.on("renderGroupStart", ({ target }) => {
- *     console.log("onRenderGroupStart", target);
+ * moveable.on("renderGroupStart", ({ targets }) => {
+ *     console.log("onRenderGroupStart", targets);
  * });
  */
 
@@ -1205,8 +1205,8 @@ class Moveable extends EgComponent implements MoveableInterface {
  * const moveable = new Moveable(document.body, {
  *     target: [].slice.call(document.querySelectorAll(".target")),
  * });
- * moveable.on("renderGroup", ({ target }) => {
- *     console.log("onRenderGroup", target);
+ * moveable.on("renderGroup", ({ targets }) => {
+ *     console.log("onRenderGroup", targets);
  * });
  */
 
@@ -1221,8 +1221,42 @@ class Moveable extends EgComponent implements MoveableInterface {
  * const moveable = new Moveable(document.body, {
  *     target: [].slice.call(document.querySelectorAll(".target")),
  * });
- * moveable.on("renderGroupEnd", ({ target }) => {
- *     console.log("onRenderGroupEnd", target);
+ * moveable.on("renderGroupEnd", ({ targets }) => {
+ *     console.log("onRenderGroupEnd", targets);
+ * });
+ */
+
+/**
+ * When the drag cursor leaves the scrollContainer, the `scroll` event occur to scroll.
+ * @memberof Moveable
+ * @event scroll
+ * @param {Moveable.OnScroll} - Parameters for the `scroll` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: document.querySelector(".target"),
+ * });
+ * moveable.on("scroll", ({ scrollContainer, direction }) => {
+ *   scrollContainer.scrollLeft += direction[0] * 10;
+ *   scrollContainer.scrollTop += direction[1] * 10;
+ * });
+ */
+
+/**
+ * When the drag cursor leaves the scrollContainer, the `scrollGroup` event occur to scroll in group.
+ * @memberof Moveable
+ * @event scrollGroup
+ * @param {Moveable.OnScrollGroup} - Parameters for the `scrollGroup` event
+ * @example
+ * import Moveable from "moveable";
+ *
+ * const moveable = new Moveable(document.body, {
+ *     target: [].slice.call(document.querySelectorAll(".target")),
+ * });
+ * moveable.on("scroll", ({ scrollContainer, direction }) => {
+ *   scrollContainer.scrollLeft += direction[0] * 10;
+ *   scrollContainer.scrollTop += direction[1] * 10;
  * });
  */
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,6 +1,6 @@
-import { MoveableEvents } from "./types";
+import { MoveableEvents, MoveableOptions } from "./types";
 
-export const PROPERTIES = [
+export const PROPERTIES: Array<keyof MoveableOptions> = [
     "draggable", "resizable", "scalable", "rotatable",
     "warpable", "pinchable", "snappable", "origin", "target", "edge",
     "throttleDrag", "throttleResize",
@@ -10,6 +10,13 @@ export const PROPERTIES = [
     "snapCenter", "snapThreshold",
     "horizontalGuidelines", "verticalGuidelines", "elementGuidelines",
     "bounds",
+
+    "className",
+    "renderDirections",
+    "scrollable",
+    "getScrollPosition",
+    "scrollContainer",
+    "scrollThreshold",
 ];
 export const EVENTS: Array<keyof MoveableEvents> = [
     "dragStart",
@@ -46,7 +53,14 @@ export const EVENTS: Array<keyof MoveableEvents> = [
     "pinchGroup",
     "pinchGroupEnd",
     "clickGroup",
+
+    "scroll",
+    "scrollGroup",
+
     "renderStart",
     "render",
     "renderEnd",
+    "renderGroupStart",
+    "renderGroup",
+    "renderGroupEnd",
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ import {
     OnResizeGroup, OnResizeGroupEnd, OnScaleGroupStart,
     OnScaleGroup, OnScaleGroupEnd, OnRotateGroupStart,
     OnRotateGroup, OnRotateGroupEnd, OnPinchGroupStart,
-    OnPinchGroup, OnPinchGroupEnd, OnClickGroup,
+    OnPinchGroup, OnPinchGroupEnd, OnClickGroup, OnRenderStart, OnRender, OnRenderEnd, OnScroll, OnScrollGroup, OnRenderGroupStart, OnRenderGroup, OnRenderGroupEnd, MoveableProps, OnClick,
 } from "react-moveable/declaration/types";
 
 /**
@@ -23,6 +23,7 @@ import {
  * @property - Whether or not target can be pinched with draggable, resizable, scalable, rotatable. (default: false)
  * @property - Whether or not target can be snapped to the guideline. (default: false)
  * @property - Whether or not the origin controlbox will be visible or not (default: false)
+ * @property - You can specify the className of the moveable controlbox. (default: "")
  * @property - The target(s) to indicate Moveable Control Box. (default: true)
  * @property - Moveable Container. (default: parentElement)
  * @property - throttle of x, y when drag. (default: 0)
@@ -39,7 +40,13 @@ import {
  * @property - Add guidelines for the element. (default: [])
  * @property - You can set up boundaries. (default: null)
  * @property - Add an event to the moveable area instead of the target for stopPropagation. (default: false)
+
  * @property - You can specify the position of the rotation. (default: "top")
+ * @property - Set directions to show the control box. (default: ["n", "nw", "ne", "s", "se", "sw", "e", "w"])
+ * @property - Whether or not target can be scrolled to the scroll container (default: false)
+ * @property - The container to which scroll is applied (default: container)
+ * @property - Expand the range of the scroll check area. (default: 0)
+ * @property - Sets a function to get the scroll position. (default: Function)
  */
 export interface MoveableOptions {
     draggable?: boolean;
@@ -49,7 +56,10 @@ export interface MoveableOptions {
     warpable?: boolean;
     pinchable?: boolean | Array<"rotatable" | "resizable" | "scalable">;
     snappable?: boolean | string[];
+
+
     origin?: boolean;
+    className?: string;
     target?: SVGElement | HTMLElement | Array<SVGElement | HTMLElement>;
     container?: SVGElement | HTMLElement | null;
     throttleDrag?: number;
@@ -69,6 +79,16 @@ export interface MoveableOptions {
 
     dragArea?: boolean;
     rotationPosition?: "top" | "bottom" | "left" | "right";
+
+    renderDirections?: string[];
+
+    scrollable?: boolean;
+    scrollContainer?: HTMLElement;
+    scrollThreshold?: number;
+    getScrollPosition?: (e: {
+        scrollContainer: HTMLElement;
+        direction: number[];
+    }) => number[];
 }
 
 export interface MoveableGetterSetter extends Pick<MoveableOptions, Exclude<keyof MoveableOptions, "container">> {
@@ -78,18 +98,30 @@ export interface MoveableEvents {
     dragStart: OnDragStart;
     drag: OnDrag;
     dragEnd: OnDragEnd;
+    dragGroupStart: OnDragGroupStart;
+    dragGroup: OnDragGroup;
+    dragGroupEnd: OnDragGroupEnd;
 
     resizeStart: OnResizeStart;
     resize: OnResize;
     resizeEnd: OnResizeEnd;
+    resizeGroupStart: OnResizeGroupStart;
+    resizeGroup: OnResizeGroup;
+    resizeGroupEnd: OnResizeGroupEnd;
 
     scaleStart: OnScaleStart;
     scale: OnScale;
     scaleEnd: OnScaleEnd;
+    scaleGroupStart: OnScaleGroupStart;
+    scaleGroup: OnScaleGroup;
+    scaleGroupEnd: OnScaleGroupEnd;
 
     rotateStart: OnRotateStart;
     rotate: OnRotate;
     rotateEnd: OnRotateEnd;
+    rotateGroupStart: OnRotateGroupStart;
+    rotateGroup: OnRotateGroup;
+    rotateGroupEnd: OnRotateGroupEnd;
 
     warpStart: OnWarpStart;
     warp: OnWarp;
@@ -99,29 +131,22 @@ export interface MoveableEvents {
     pinch: OnPinch;
     pinchEnd: OnPinchEnd;
 
-    dragGroupStart: OnDragGroupStart;
-    dragGroup: OnDragGroup;
-    dragGroupEnd: OnDragGroupEnd;
-
-    resizeGroupStart: OnResizeGroupStart;
-    resizeGroup: OnResizeGroup;
-    resizeGroupEnd: OnResizeGroupEnd;
-
-    scaleGroupStart: OnScaleGroupStart;
-    scaleGroup: OnScaleGroup;
-    scaleGroupEnd: OnScaleGroupEnd;
-
-    rotateGroupStart: OnRotateGroupStart;
-    rotateGroup: OnRotateGroup;
-    rotateGroupEnd: OnRotateGroupEnd;
+    renderStart: OnRenderStart;
+    render: OnRender;
+    renderEnd: OnRenderEnd;
+    renderGroupStart: OnRenderGroupStart;
+    renderGroup: OnRenderGroup;
+    renderGroupEnd: OnRenderGroupEnd;
 
     pinchGroupStart: OnPinchGroupStart;
     pinchGroup: OnPinchGroup;
     pinchGroupEnd: OnPinchGroupEnd;
 
+    click: OnClick;
     clickGroup: OnClickGroup;
 
-    renderStart: {};
-    render: {};
-    renderEnd: {};
+    scroll: OnScroll;
+    scrollGroup: OnScrollGroup;
+
+
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,9 @@ import {
     OnResizeGroup, OnResizeGroupEnd, OnScaleGroupStart,
     OnScaleGroup, OnScaleGroupEnd, OnRotateGroupStart,
     OnRotateGroup, OnRotateGroupEnd, OnPinchGroupStart,
-    OnPinchGroup, OnPinchGroupEnd, OnClickGroup, OnRenderStart, OnRender, OnRenderEnd, OnScroll, OnScrollGroup, OnRenderGroupStart, OnRenderGroup, OnRenderGroupEnd, MoveableProps, OnClick,
+    OnPinchGroup, OnPinchGroupEnd, OnClickGroup, OnRenderStart,
+    OnRender, OnRenderEnd, OnScroll, OnScrollGroup, OnRenderGroupStart,
+    OnRenderGroup, OnRenderGroupEnd, OnClick,
 } from "react-moveable/declaration/types";
 
 /**
@@ -56,7 +58,6 @@ export interface MoveableOptions {
     warpable?: boolean;
     pinchable?: boolean | Array<"rotatable" | "resizable" | "scalable">;
     snappable?: boolean | string[];
-
 
     origin?: boolean;
     className?: string;
@@ -147,6 +148,4 @@ export interface MoveableEvents {
 
     scroll: OnScroll;
     scrollGroup: OnScrollGroup;
-
-
 }


### PR DESCRIPTION
### Added
* Add `scrollable` props. #39
    * Add `onScroll`, `onScrollGroup` event
    * Add `scrollContainer` props
    * Add `getScrollPosition` props
* Add `currentTarget` and `inputEvent` on all events #74 #86
* Add `setState` method #82
* Add `getRect` method #71
* Add `renderDirection` props #63
* Add `className` props #53 #63
* Add `onClick` event
* Add `onRenderStart`, `onRender`, `onRenderEnd` events #52
* Add `onRenderGroupStart`, `onRenderGroup`, `onRenderGroupEnd` events #52

### Fixed
* Fix target's boundingRect matrix caculation with scroll position
* Fix problem where the ratio is not maintained with keepRatio #70
* Fix that `el is undefined` #73
* Fix `dragArea`'s caculation
* Fix that `dragStart` method is not work with group
* Fix that `clickGroup` event occurs when `dragStart` a mousedown target
* Fix that Moveable is deleted when a single target is changed to multiple targets