### PR TITLE
Tiny fix: keep rad=0 as 0 to avoid rounding errors

### DIFF
--- a/packages/matrix/src/index.ts
+++ b/packages/matrix/src/index.ts
@@ -118,7 +118,7 @@ export function getRad(pos1: number[], pos2: number[]) {
     const distY = pos2[1] - pos1[1];
     const rad = Math.atan2(distY, distX);
 
-    return rad > 0 ? rad : rad + Math.PI * 2;
+    return rad >= 0 ? rad : rad + Math.PI * 2;
 }
 
 export function getOrigin(matrix: number[], n: number = Math.sqrt(matrix.length)) {


### PR DESCRIPTION
Currently, `rad=0` is recalculated as `Math.PI * 2` and then rounded. Thus the typical transform is `transform: ... rotate(6.28319rad)`. Due to this there are some rendering issues in some browsers that look like this:

<img width="171" alt="Screen Shot 2019-12-18 at 2 52 47 PM" src="https://user-images.githubusercontent.com/726049/71130324-6c17ac80-21a6-11ea-90fc-a2a52bc62f7a.png">

The requested fix is to keep `rad=0` as `rotate(0rad)`