### PR TITLE
Support full edges resize

### DIFF
--- a/packages/react-moveable/src/react-moveable/renderDirection.tsx
+++ b/packages/react-moveable/src/react-moveable/renderDirection.tsx
@@ -15,6 +15,7 @@ export function renderControls(
     } = moveable.state;
     const {
         renderDirections: directions = defaultDirections,
+        fullEdgesResize,
     } = moveable.props;
     const poses = [pos1, pos2, pos3, pos4];
 
@@ -28,9 +29,33 @@ export function renderControls(
         if (!indexes || !directionMap[direction]) {
             return null;
         }
+        
+        const baseStyle = getControlTransform(rotation, ...indexes.map((index) => poses[index]));
+        const style: React.CSSProperties = Object.assign(baseStyle, {});
+
+        if (fullEdgesResize) {
+            style.borderRadius = 0;
+
+            if (direction === 's' || direction === 'n') {
+                style.width = width - 10;
+                style.height = 20;
+                style.marginTop = '-10px';
+                style.marginLeft = -width / 2 + 5;
+                style.background = 'transparent';
+                style.border = 'none';
+            } else if (direction === 'e' || direction === 'w') {
+                style.height = height - 10;
+                style.width = 20;
+                style.marginLeft = '-10px';
+                style.marginTop = -height / 2 + 5;
+                style.background = 'transparent';
+                style.border = 'none';
+            }
+        }
+
         return (
             <div className={prefix("control", "direction", direction)} data-direction={direction} key={direction}
-                style={getControlTransform(rotation, ...indexes.map(index => poses[index]))}></div>
+                style={style}></div>
         );
     });
 }

--- a/packages/react-moveable/src/react-moveable/renderDirection.tsx
+++ b/packages/react-moveable/src/react-moveable/renderDirection.tsx
@@ -12,6 +12,8 @@ export function renderControls(
     const {
         pos1, pos2, pos3, pos4,
         rotation,
+        width,
+        height,
     } = moveable.state;
     const {
         renderDirections: directions = defaultDirections,
@@ -29,7 +31,7 @@ export function renderControls(
         if (!indexes || !directionMap[direction]) {
             return null;
         }
-        
+
         const baseStyle = getControlTransform(rotation, ...indexes.map((index) => poses[index]));
         const style: React.CSSProperties = Object.assign(baseStyle, {});
 

--- a/packages/react-moveable/src/react-moveable/types.ts
+++ b/packages/react-moveable/src/react-moveable/types.ts
@@ -712,6 +712,8 @@ export interface ResizableProps {
     renderDirections?: string[];
     baseDirection?: number[];
     keepRatio?: boolean;
+    /**Resizeable full along edges*/
+    fullEdgesResize?: boolean;
 
     onResizeStart?: (e: OnResizeStart) => any;
     onResize?: (e: OnResize) => any;


### PR DESCRIPTION
Add an option `fullEdgesResize` to let user choose where they can resize full along edges.

Using:
`<Moveable ......fullEdgesResize={true}...>`
![captured (5)](https://user-images.githubusercontent.com/51266596/72125160-22337800-339a-11ea-976f-20a2469178ff.gif)
