### PR TITLE
fix: fix typo caculate -> calculate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,9 +98,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * `svelte-moveable` 0.9.3
 
 ### Fixed
-* Fix Safari Offset Caculation #285
-* Fix SVG Transform Origin Caculation #286
-* Fix SVG ClientSize Caculation #288
+* Fix Safari Offset Calculation #285
+* Fix SVG Transform Origin Calculation #286
+* Fix SVG ClientSize Calculation #288
 
 
 ## [0.18.4] - 2020-07-15
@@ -193,7 +193,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 * Fix CSS's camelized name issue #243
-* Fix wrong maxWidth, maxHeight caculation issue for `innerBounds` and `bounds`  #221 #245 #241 #235
+* Fix wrong maxWidth, maxHeight calculation issue for `innerBounds` and `bounds`  #221 #245 #241 #235
 * Remove `@types/react` , `@types/react-dom` #240
 * Fix `@daybrush/drag`'s version issue #239
 
@@ -218,7 +218,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 * Fix client position #220
-* Caculate min, max size for Resizable #231
+* Calculate min, max size for Resizable #231
 
 ## [0.17.4] - 2020-05-05
 * `moveable` 0.17.4
@@ -382,7 +382,7 @@ https://github.com/daybrush/moveable/milestone/8
 
 ### Fixed
 * Fixed that control points rotation is wrong bug #151
-* Fixed that Scrollable isn't working. (wrong caculation) #150
+* Fixed that Scrollable isn't working. (wrong calculation) #150
 * Fixed that Crash of ngx-moveable when using --prod on angular bug #129
 
 ## [0.13.3] - 2019-12-30
@@ -448,7 +448,7 @@ https://github.com/daybrush/moveable/milestone/8
 
 ## [0.11.1] - 2019-11-23
 ### Fixed
-* Fix Resizable's base direction caculation
+* Fix Resizable's base direction calculation
 
 ## [0.11.0] - 2019-11-23
 ### Added
@@ -501,17 +501,17 @@ https://github.com/daybrush/moveable/milestone/8
 * Add `warp` in top, right, bottom and left directions.
 
 ### Fixed
-* Fix target's boundingRect matrix caculation with scroll position
+* Fix target's boundingRect matrix calculation with scroll position
 * Fix problem where the ratio is not maintained with keepRatio #70
 * Fix that `el is undefined` #73
-* Fix `dragArea`'s caculation
+* Fix `dragArea`'s calculation
 * Fix that `dragStart` method is not work with group
 * Fix that `clickGroup` event occurs when `dragStart` a mousedown target
 * Fix that Moveable is deleted when a single target is changed to multiple targets
 
 ## [0.9.8] - 2019-10-26
 ### Fixed
-* Fix that miscaculate static parent's offset position
+* Fix that miscalculate static parent's offset position
 * Fix dragArea's transformOrigin
 
 ## [0.9.7] - 2019-10-16
@@ -532,7 +532,7 @@ https://github.com/daybrush/moveable/milestone/8
 ### Fixed
 * fix that resizing north, west direction occur decimal point issue.
 * Disable pinchable with snappable.
-* Fix offset caculation for Webkit
+* Fix offset calculation for Webkit
 
 ## [0.9.3] - 2019-10-01
 ### Fixed
@@ -562,7 +562,7 @@ https://github.com/daybrush/moveable/milestone/8
 
 ### Fixed
 * north and west controls want to behave like photoshop (#9)
-* Fix offset caculation for Webkit
+* Fix offset calculation for Webkit
 
 
 ## [0.8.0] - 2019-08-28

--- a/README.md
+++ b/README.md
@@ -258,8 +258,8 @@ You will also see any lint errors in the console.
 ### Files related to major features.
 
 * Ables: https://github.com/daybrush/moveable/tree/master/packages/react-moveable/src/react-moveable/ables
-* Caculate Matrix Stack: https://github.com/daybrush/moveable/blob/master/packages/react-moveable/src/react-moveable/utils.ts
-  (`caculateElementInfo` function)
+* Calculate Matrix Stack: https://github.com/daybrush/moveable/blob/master/packages/react-moveable/src/react-moveable/utils.ts
+  (`calculateElementInfo` function)
 * Render Moveable Controls: https://github.com/daybrush/moveable/blob/master/packages/react-moveable/src/react-moveable/MoveableManager.tsx
 * Render Moveable Group: https://github.com/daybrush/moveable/blob/master/packages/react-moveable/src/react-moveable/MoveableGroup.tsx
 

--- a/packages/react-moveable/README.md
+++ b/packages/react-moveable/README.md
@@ -276,8 +276,8 @@ You will also see any lint errors in the console.
 ### Files related to major features.
 
 * Ables: https://github.com/daybrush/moveable/tree/master/packages/react-moveable/src/react-moveable/ables
-* Caculate Matrix Stack: https://github.com/daybrush/moveable/blob/master/packages/react-moveable/src/react-moveable/utils.ts
-  (`caculateElementInfo` function)
+* Calculate Matrix Stack: https://github.com/daybrush/moveable/blob/master/packages/react-moveable/src/react-moveable/utils.ts
+  (`calculateElementInfo` function)
 * Render Moveable Controls: https://github.com/daybrush/moveable/blob/master/packages/react-moveable/src/react-moveable/MoveableManager.tsx
 * Render Moveable Group: https://github.com/daybrush/moveable/blob/master/packages/react-moveable/src/react-moveable/MoveableGroup.tsx
 

--- a/packages/react-moveable/src/react-moveable/MoveableManager.tsx
+++ b/packages/react-moveable/src/react-moveable/MoveableManager.tsx
@@ -11,7 +11,7 @@ import {
     equals,
     flat,
     groupByMap,
-    caculatePadding,
+    calculatePadding,
 } from "./utils";
 import Gesto from "gesto";
 import { ref } from "framework-utils";
@@ -529,10 +529,10 @@ export default class MoveableManager<T = {}>
         const absoluteOrigin = (props as any).groupable ? beforeOrigin : plus(beforeOrigin, [stateLeft, stateTop]);
 
         state.renderPoses = [
-            plus(pos1, caculatePadding(allMatrix, [-left, -top], transformOrigin, absoluteOrigin, n)),
-            plus(pos2, caculatePadding(allMatrix, [right, -top], transformOrigin, absoluteOrigin, n)),
-            plus(pos3, caculatePadding(allMatrix, [-left, bottom], transformOrigin, absoluteOrigin, n)),
-            plus(pos4, caculatePadding(allMatrix, [right, bottom], transformOrigin, absoluteOrigin, n)),
+            plus(pos1, calculatePadding(allMatrix, [-left, -top], transformOrigin, absoluteOrigin, n)),
+            plus(pos2, calculatePadding(allMatrix, [right, -top], transformOrigin, absoluteOrigin, n)),
+            plus(pos3, calculatePadding(allMatrix, [-left, bottom], transformOrigin, absoluteOrigin, n)),
+            plus(pos4, calculatePadding(allMatrix, [right, bottom], transformOrigin, absoluteOrigin, n)),
         ];
     }
     public checkUpdate() {

--- a/packages/react-moveable/src/react-moveable/ables/Clippable.tsx
+++ b/packages/react-moveable/src/react-moveable/ables/Clippable.tsx
@@ -5,13 +5,13 @@ import {
 } from "../types";
 import { splitBracket, splitComma, splitUnit, splitSpace, convertUnitSize } from "@daybrush/utils";
 import {
-    prefix, caculatePosition, getDiagonalSize,
+    prefix, calculatePosition, getDiagonalSize,
     fillParams, triggerEvent,
     makeMatrixCSS, getRect, fillEndParams,
     convertCSSSize, moveControlPos,
 } from "../utils";
 import { getRad, plus, minus } from "../matrix";
-import { setDragStart, getDragDist, caculatePointerDist } from "../gesto/GestoUtils";
+import { setDragStart, getDragDist, calculatePointerDist } from "../gesto/GestoUtils";
 import {
     getRadiusValues,
     HORIZONTAL_RADIUS_ORDER, VERTICAL_RADIUS_ORDER, getRadiusStyles, addRadiusPos, removeRadiusPos
@@ -298,7 +298,7 @@ function getClipPath(
     return;
 }
 function addClipPath(moveable: MoveableManagerInterface<ClippableProps>, e: any) {
-    const [distX, distY] = caculatePointerDist(moveable, e);
+    const [distX, distY] = calculatePointerDist(moveable, e);
     const { clipPath, index } = e.datas;
     const {
         type: clipType,
@@ -468,11 +468,11 @@ export default {
         const clipPoses = clipPath.poses;
         const poses = clipPoses.map(pos => {
             // return [x, y];
-            const caculatedPos = caculatePosition(allMatrix, pos.pos, n);
+            const calculatedPos = calculatePosition(allMatrix, pos.pos, n);
 
             return [
-                caculatedPos[0] - left,
-                caculatedPos[1] - top,
+                calculatedPos[0] - left,
+                calculatedPos[1] - top,
             ];
         });
 
@@ -527,8 +527,8 @@ export default {
             } = clipPath;
 
             const [distLeft, distTop] = minus(
-                caculatePosition(allMatrix, [clipLeft!, clipTop!], n),
-                caculatePosition(allMatrix, [0, 0], n),
+                calculatePosition(allMatrix, [clipLeft!, clipTop!], n),
+                calculatePosition(allMatrix, [0, 0], n),
             );
             let ellipseClipPath = "none";
 
@@ -584,9 +584,9 @@ export default {
                 const isHorizontal = directionType === "horizontal";
                 if (info.isSnap) {
                     lines.push(...info.snap.posInfos.map(({ pos }, i) => {
-                        const snapPos1 = minus(caculatePosition(
+                        const snapPos1 = minus(calculatePosition(
                             allMatrix, isHorizontal ? [0, pos] : [pos, 0], n), [left, top]);
-                        const snapPos2 = minus(caculatePosition(
+                        const snapPos2 = minus(calculatePosition(
                             allMatrix, isHorizontal ? [width, pos] : [pos, height], n), [left, top]);
 
                         return renderLine(
@@ -596,9 +596,9 @@ export default {
                 }
                 if (info.isBound) {
                     lines.push(...info.bounds.map(({ pos }, i) => {
-                        const snapPos1 = minus(caculatePosition(
+                        const snapPos1 = minus(calculatePosition(
                             allMatrix, isHorizontal ? [0, pos] : [pos, 0], n), [left, top]);
-                        const snapPos2 = minus(caculatePosition(
+                        const snapPos2 = minus(calculatePosition(
                             allMatrix, isHorizontal ? [width, pos] : [pos, height], n), [left, top]);
 
                         return renderLine(

--- a/packages/react-moveable/src/react-moveable/ables/DragArea.tsx
+++ b/packages/react-moveable/src/react-moveable/ables/DragArea.tsx
@@ -2,7 +2,7 @@ import {
     createWarpMatrix,
 } from "../matrix";
 import { ref } from "framework-utils";
-import { getRect, caculateInversePosition, makeMatrixCSS, prefix } from "../utils";
+import { getRect, calculateInversePosition, makeMatrixCSS, prefix } from "../utils";
 import {
     Renderer, GroupableProps, DragAreaProps, MoveableManagerInterface, MoveableGroupInterface
 } from "../types";
@@ -94,7 +94,7 @@ export default {
             height,
         } = getRect(renderPoses);
         const n = is3d ? 4 : 3;
-        let [posX, posY] = caculateInversePosition(rootMatrix, [clientX - left, clientY - top], n);
+        let [posX, posY] = calculateInversePosition(rootMatrix, [clientX - left, clientY - top], n);
 
         posX -= relativeLeft;
         posY -= relativeTop;

--- a/packages/react-moveable/src/react-moveable/ables/OriginDraggable.tsx
+++ b/packages/react-moveable/src/react-moveable/ables/OriginDraggable.tsx
@@ -1,6 +1,6 @@
 import {
     prefix, triggerEvent,
-    fillParams, caculatePoses, getRect, fillEndParams, convertCSSSize
+    fillParams, calculatePoses, getRect, fillEndParams, convertCSSSize
 } from "../utils";
 import {
     OnDragOriginStart, OnDragOrigin,
@@ -104,7 +104,7 @@ export default {
         );
 
         const rect = moveable.getRect();
-        const nextRect = getRect(caculatePoses(nextMatrix, width, height, n));
+        const nextRect = getRect(calculatePoses(nextMatrix, width, height, n));
 
         const dragDelta = [
             rect.left - nextRect.left,

--- a/packages/react-moveable/src/react-moveable/ables/Resizable.ts
+++ b/packages/react-moveable/src/react-moveable/ables/Resizable.ts
@@ -20,10 +20,10 @@ import {
     triggerChildAble,
 } from "../groupUtils";
 import Draggable from "./Draggable";
-import { getRad, caculate, createRotateMatrix, plus } from "../matrix";
+import { getRad, calculate, createRotateMatrix, plus } from "../matrix";
 import CustomGesto, { setCustomDrag } from "../gesto/CustomGesto";
 import { checkSnapSize } from "./Snappable";
-import { caculateBoundSize, IObject, isString } from "@daybrush/utils";
+import { calculateBoundSize, IObject, isString } from "@daybrush/utils";
 import { TINY_NUM } from "../consts";
 
 /**
@@ -341,7 +341,7 @@ export default {
                 nextHeight = throttle(nextHeight, throttleResize!);
             }
         }
-        [nextWidth, nextHeight] = caculateBoundSize(
+        [nextWidth, nextHeight] = calculateBoundSize(
             [nextWidth, nextHeight],
             minSize,
             maxSize,
@@ -454,7 +454,7 @@ export default {
             e,
             (child, ev) => {
                 const pos = getAbsoluteFixedPosition(child, direction);
-                const [originalX, originalY] = caculate(
+                const [originalX, originalY] = calculate(
                     createRotateMatrix(-moveable.rotation / 180 * Math.PI, 3),
                     [pos[0] - fixedPosition[0], pos[1] - fixedPosition[1], 1],
                     3,
@@ -504,7 +504,7 @@ export default {
             "dragControl",
             e,
             (_, ev) => {
-                const [clientX, clientY] = caculate(
+                const [clientX, clientY] = calculate(
                     createRotateMatrix(moveable.rotation / 180 * Math.PI, 3),
                     [
                         ev.datas.originalX * parentScale[0],

--- a/packages/react-moveable/src/react-moveable/ables/Rotatable.tsx
+++ b/packages/react-moveable/src/react-moveable/ables/Rotatable.tsx
@@ -1,6 +1,6 @@
 import {
     throttle, prefix, triggerEvent, fillParams,
-    getClientRect, caculatePosition, fillEndParams
+    getClientRect, calculatePosition, fillEndParams
 } from "../utils";
 import { IObject, hasClass } from "@daybrush/utils";
 import {
@@ -37,7 +37,7 @@ function setRotateStartInfo(
     datas: IObject<any>, clientX: number, clientY: number, origin: number[], rect: MoveableClientRect) {
 
     const n = moveable.state.is3d ? 4 : 3;
-    const nextOrigin = caculatePosition(moveable.state.rootMatrix, origin, n);
+    const nextOrigin = calculatePosition(moveable.state.rootMatrix, origin, n);
     const startAbsoluteOrigin = plus([rect.left, rect.top], nextOrigin);
 
     datas.startAbsoluteOrigin = startAbsoluteOrigin;

--- a/packages/react-moveable/src/react-moveable/ables/Roundable.tsx
+++ b/packages/react-moveable/src/react-moveable/ables/Roundable.tsx
@@ -1,12 +1,12 @@
 import {
     prefix, triggerEvent,
-    fillParams, fillEndParams, caculatePosition
+    fillParams, fillEndParams, calculatePosition
 } from "../utils";
 import {
     Renderer, RoundableProps, OnRoundStart, RoundableState, OnRound, ControlPose, OnRoundEnd, MoveableManagerInterface,
 } from "../types";
 import { splitSpace } from "@daybrush/utils";
-import { setDragStart, getDragDist, caculatePointerDist } from "../gesto/GestoUtils";
+import { setDragStart, getDragDist, calculatePointerDist } from "../gesto/GestoUtils";
 import { minus, plus } from "../matrix";
 import {
     getRadiusValues, getRadiusStyles, removeRadiusPos,
@@ -205,7 +205,7 @@ export default {
         return radiusValues.map((v, i) => {
             horizontalCount += Math.abs(v.horizontal);
             verticalCount += Math.abs(v.vertical);
-            const pos = minus(caculatePosition(allMatrix, v.pos, n), [left, top]);
+            const pos = minus(calculatePosition(allMatrix, v.pos, n), [left, top]);
             const isDisplay = v.vertical
                 ? verticalCount <= maxRoundControls[1]
                 : horizontalCount <= maxRoundControls[0];
@@ -371,7 +371,7 @@ export default {
             if (isControl) {
                 removeRadiusPos(controlPoses, poses, controlIndex, 0);
             } else if (isLine) {
-                const [distX, distY] = caculatePointerDist(moveable, e);
+                const [distX, distY] = calculatePointerDist(moveable, e);
 
                 addBorderRadius(controlPoses, poses, lineIndex, distX, distY, width, height);
             }

--- a/packages/react-moveable/src/react-moveable/ables/Scalable.ts
+++ b/packages/react-moveable/src/react-moveable/ables/Scalable.ts
@@ -24,7 +24,7 @@ import {
     triggerChildAble,
 } from "../groupUtils";
 import Draggable from "./Draggable";
-import { getRad, caculate, createRotateMatrix, plus, minus } from "../matrix";
+import { getRad, calculate, createRotateMatrix, plus, minus } from "../matrix";
 import CustomGesto from "../gesto/CustomGesto";
 import { checkSnapScale } from "./Snappable";
 import { isArray, IObject } from "@daybrush/utils";
@@ -378,7 +378,7 @@ export default {
             (child, ev) => {
                 const pos = getAbsoluteFixedPosition(child, direction);
 
-                const [originalX, originalY] = caculate(
+                const [originalX, originalY] = calculate(
                     createRotateMatrix(-moveable.rotation / 180 * Math.PI, 3),
                     [pos[0] - fixedPosition[0], pos[1] - fixedPosition[1], 1],
                     3,
@@ -427,7 +427,7 @@ export default {
             "dragControl",
             e,
             (_, ev) => {
-                const [clientX, clientY] = caculate(
+                const [clientX, clientY] = calculate(
                     createRotateMatrix(moveable.rotation / 180 * Math.PI, 3),
                     [
                         ev.datas.originalX * dist[0],

--- a/packages/react-moveable/src/react-moveable/ables/Snappable.tsx
+++ b/packages/react-moveable/src/react-moveable/ables/Snappable.tsx
@@ -9,10 +9,10 @@ import {
     SnappableOptions, MoveableClientRect, MoveableManagerInterface, SnappableRenderType, BoundType, SnapBoundInfo,
 } from "../types";
 import {
-    prefix, caculatePoses, getRect,
+    prefix, calculatePoses, getRect,
     getAbsolutePosesByState, getAbsolutePoses, throttle, roundSign,
     getDistSize, groupBy, flat, maxOffset, minOffset,
-    triggerEvent, caculateInversePosition, caculatePosition,
+    triggerEvent, calculateInversePosition, calculatePosition,
     directionCondition,
 } from "../utils";
 import { IObject, find, findIndex, hasClass } from "@daybrush/utils";
@@ -38,12 +38,12 @@ import {
     checkSnapPoses,
 } from "./snappable/snap";
 
-export function caculateContainerPos(
+export function calculateContainerPos(
     rootMatrix: number[],
     containerRect: MoveableClientRect,
     n: number,
 ) {
-    const clientPos = caculatePosition(
+    const clientPos = calculatePosition(
         rootMatrix, [containerRect.clientLeft!, containerRect.clientTop!], n);
 
     return [
@@ -85,11 +85,11 @@ export function snapStart(moveable: MoveableManagerInterface<SnappableProps, Sna
         is3d,
     } = state;
     const n = is3d ? 4 : 3;
-    const [containerLeft, containerTop] = caculateContainerPos(rootMatrix, containerClientRect, n);
+    const [containerLeft, containerTop] = calculateContainerPos(rootMatrix, containerClientRect, n);
     const poses = getAbsolutePosesByState(state);
     const targetLeft = Math.min(...poses.map(pos => pos[0]));
     const targetTop = Math.min(...poses.map(pos => pos[1]));
-    const [distLeft, distTop] = minus([targetLeft, targetTop], caculateInversePosition(rootMatrix, [
+    const [distLeft, distTop] = minus([targetLeft, targetTop], calculateInversePosition(rootMatrix, [
         clientLeft - containerLeft,
         clientTop - containerTop,
     ], n)).map(pos => roundSign(pos));
@@ -102,8 +102,8 @@ export function snapStart(moveable: MoveableManagerInterface<SnappableProps, Sna
         const top = rect.top - containerTop;
         const bottom = top + rect.height;
         const right = left + rect.width;
-        const [elementLeft, elementTop] = caculateInversePosition(rootMatrix, [left, top], n);
-        const [elementRight, elementBottom] = caculateInversePosition(rootMatrix, [right, bottom], n);
+        const [elementLeft, elementTop] = calculateInversePosition(rootMatrix, [left, top], n);
+        const [elementRight, elementBottom] = calculateInversePosition(rootMatrix, [right, bottom], n);
         const width = elementRight - elementLeft;
         const height = elementBottom - elementTop;
         const sizes = [width, height];
@@ -236,7 +236,7 @@ function getNextFixedPoses(
     direction: number[],
     is3d: boolean,
 ) {
-    const nextPoses = caculatePoses(matrix, width, height, is3d ? 4 : 3);
+    const nextPoses = calculatePoses(matrix, width, height, is3d ? 4 : 3);
     const nextPos = getPosByReverseDirection(nextPoses, direction);
 
     return getAbsolutePoses(nextPoses, minus(fixedPos, nextPos));
@@ -1566,8 +1566,8 @@ z-index: 2;
         const n = is3d ? 4 : 3;
         const minLeft = Math.min(pos1[0], pos2[0], pos3[0], pos4[0]);
         const minTop = Math.min(pos1[1], pos2[1], pos3[1], pos4[1]);
-        const containerPos = caculateContainerPos(rootMatrix, containerClientRect, n);
-        const [clientLeft, clientTop] = caculateInversePosition(rootMatrix, [
+        const containerPos = calculateContainerPos(rootMatrix, containerClientRect, n);
+        const [clientLeft, clientTop] = calculateInversePosition(rootMatrix, [
             targetClientRect.left - containerPos[0],
             targetClientRect.top - containerPos[1],
         ], n);

--- a/packages/react-moveable/src/react-moveable/ables/Warpable.tsx
+++ b/packages/react-moveable/src/react-moveable/ables/Warpable.tsx
@@ -4,7 +4,7 @@ import {
  } from "../utils";
 import {
     convertDimension, invert, multiply,
-    caculate,
+    calculate,
     createIdentityMatrix,
     ignoreDimension,
     minus,
@@ -136,7 +136,7 @@ export default {
             [width, height],
         ].map(p => minus(p, transformOrigin));
 
-        datas.nextPoses = datas.poses.map(([x, y]: number[]) => caculate(datas.warpTargetMatrix, [x, y, 0, 1], 4));
+        datas.nextPoses = datas.poses.map(([x, y]: number[]) => calculate(datas.warpTargetMatrix, [x, y, 0, 1], 4));
         datas.startValue = createIdentityMatrix(4);
         datas.prevMatrix = createIdentityMatrix(4);
         datas.absolutePoses = getAbsolutePosesByState(state);

--- a/packages/react-moveable/src/react-moveable/ables/roundable/borderRadius.tsx
+++ b/packages/react-moveable/src/react-moveable/ables/roundable/borderRadius.tsx
@@ -4,7 +4,7 @@ import { convertUnitSize } from "@daybrush/utils";
 
 const RADIUS_DIRECTIONS = ["nw", "ne", "se", "sw"] as const;
 
-function caculateRatio(values: number[], size: number) {
+function calculateRatio(values: number[], size: number) {
     const sumSize = values[0] + values[1];
     const sumRatio = sumSize > size ? size / sumSize : 1;
 
@@ -118,10 +118,10 @@ export function getRadiusValues(
     const horizontalPoses = horizontalRawPoses.slice();
     const verticalPoses = verticalRawPoses.slice();
 
-    [horizontalPoses[0], horizontalPoses[1]] = caculateRatio([horizontalPoses[0], horizontalPoses[1]], width);
-    [horizontalPoses[3], horizontalPoses[2]] = caculateRatio([horizontalPoses[3], horizontalPoses[2]], width);
-    [verticalPoses[0], verticalPoses[3]] = caculateRatio([verticalPoses[0], verticalPoses[3]], height);
-    [verticalPoses[1], verticalPoses[2]] = caculateRatio([verticalPoses[1], verticalPoses[2]], height);
+    [horizontalPoses[0], horizontalPoses[1]] = calculateRatio([horizontalPoses[0], horizontalPoses[1]], width);
+    [horizontalPoses[3], horizontalPoses[2]] = calculateRatio([horizontalPoses[3], horizontalPoses[2]], width);
+    [verticalPoses[0], verticalPoses[3]] = calculateRatio([verticalPoses[0], verticalPoses[3]], height);
+    [verticalPoses[1], verticalPoses[2]] = calculateRatio([verticalPoses[1], verticalPoses[2]], height);
 
     const nextHorizontalPoses
         = horizontalPoses.slice(0, Math.max(minCounts[0], horizontalValues.length));

--- a/packages/react-moveable/src/react-moveable/gesto/GestoUtils.ts
+++ b/packages/react-moveable/src/react-moveable/gesto/GestoUtils.ts
@@ -1,11 +1,11 @@
 import {
-    invert, caculate, minus, plus,
+    invert, calculate, minus, plus,
     convertPositionMatrix, average,
     createScaleMatrix, multiply, fromTranslation, convertDimension,
 } from "../matrix";
 import {
-    caculatePoses, getAbsoluteMatrix, getAbsolutePosesByState,
-    caculatePosition, caculateInversePosition, getTransform, caculateMoveablePosition
+    calculatePoses, getAbsoluteMatrix, getAbsolutePosesByState,
+    calculatePosition, calculateInversePosition, getTransform, calculateMoveablePosition
 } from "../utils";
 import { splitUnit, isArray, splitSpace } from "@daybrush/utils";
 import {
@@ -16,7 +16,7 @@ import Draggable from "../ables/Draggable";
 import { setCustomDrag } from "./CustomGesto";
 import { parse, parseMat } from "css-to-mat";
 
-export function caculatePointerDist(moveable: MoveableManagerInterface, e: any) {
+export function calculatePointerDist(moveable: MoveableManagerInterface, e: any) {
     const { clientX, clientY, datas } = e;
     const {
         moveableClientRect,
@@ -26,7 +26,7 @@ export function caculatePointerDist(moveable: MoveableManagerInterface, e: any) 
     } = moveable.state;
     const { left, top } = moveableClientRect;
     const n = is3d ? 4 : 3;
-    const [posX, posY] = minus(caculateInversePosition(rootMatrix, [clientX - left, clientY - top], n), pos1);
+    const [posX, posY] = minus(calculateInversePosition(rootMatrix, [clientX - left, clientY - top], n), pos1);
     const [distX, distY] = getDragDist({ datas, distX: posX, distY: posY });
 
     return [distX, distY];
@@ -55,11 +55,11 @@ export function setDragStart(moveable: MoveableManagerInterface<any>, { datas }:
     datas.inverseMatrix = invert(allMatrix, n);
     datas.inverseBeforeMatrix = invert(beforeMatrix, n);
     datas.absoluteOrigin = convertPositionMatrix(plus([left, top], origin), n);
-    datas.startDragBeforeDist = caculate(datas.inverseBeforeMatrix, datas.absoluteOrigin, n);
-    datas.startDragDist = caculate(datas.inverseMatrix, datas.absoluteOrigin, n);
+    datas.startDragBeforeDist = calculate(datas.inverseBeforeMatrix, datas.absoluteOrigin, n);
+    datas.startDragDist = calculate(datas.inverseMatrix, datas.absoluteOrigin, n);
 }
 export function getTransformDirection(e: any) {
-    return caculateMoveablePosition(e.datas.beforeTransform, [50, 50], 100, 100).direction;
+    return calculateMoveablePosition(e.datas.beforeTransform, [50, 50], 100, 100).direction;
 }
 export function resolveTransformEvent(event: any, functionName: string) {
     const {
@@ -105,7 +105,7 @@ export function getTransformDist({ datas, distX, distY }: any) {
 
     const res = getTransfromMatrix(datas, fromTranslation([bx, by], 4));
 
-    return caculate(res, convertPositionMatrix([0, 0, 0], 4), 4);
+    return calculate(res, convertPositionMatrix([0, 0, 0], 4), 4);
 }
 export function getTransfromMatrix(datas: any, targetMatrix: number[], isAfter?: boolean) {
     const {
@@ -143,7 +143,7 @@ export function getBeforeDragDist({ datas, distX, distY }: any) {
     // ABS_ORIGIN * [distX, distY] = BM * (ORIGIN + [tx, ty])
     // BM -1 * ABS_ORIGIN * [distX, distY] - ORIGIN = [tx, ty]
     return minus(
-        caculate(
+        calculate(
             inverseBeforeMatrix,
             plus(absoluteOrigin, [distX, distY]),
             n,
@@ -163,7 +163,7 @@ export function getDragDist({ datas, distX, distY }: any, isBefore?: boolean) {
     const n = is3d ? 4 : 3;
 
     return minus(
-        caculate(
+        calculate(
             isBefore ? inverseBeforeMatrix : inverseMatrix,
             plus(absoluteOrigin, [distX, distY]),
             n,
@@ -183,7 +183,7 @@ export function getInverseDragDist({ datas, distX, distY }: any, isBefore?: bool
     const n = is3d ? 4 : 3;
 
     return minus(
-        caculate(
+        calculate(
             isBefore ? beforeMatrix : matrix,
             plus(isBefore ? startDragBeforeDist : startDragDist, [distX, distY]),
             n,
@@ -192,7 +192,7 @@ export function getInverseDragDist({ datas, distX, distY }: any, isBefore?: bool
     );
 }
 
-export function caculateTransformOrigin(
+export function calculateTransformOrigin(
     transformOrigin: string[],
     width: number,
     height: number,
@@ -290,7 +290,7 @@ function getDist(
     n: number,
     direction: number[],
 ) {
-    const poses = caculatePoses(matrix, width, height, n);
+    const poses = calculatePoses(matrix, width, height, n);
     const pos = getPosByReverseDirection(poses, direction);
     const distX = startPos[0] - pos[0];
     const distY = startPos[1] - pos[1];
@@ -495,7 +495,7 @@ export function getDirectionOffset(
         width / 2 * (1 + direction[0]),
         height / 2 * (1 + direction[1]),
     ];
-    return caculatePosition(nextMatrix, nextFixedOffset, n);
+    return calculatePosition(nextMatrix, nextFixedOffset, n);
 }
 export function getRotateDist(
     moveable: MoveableManagerInterface<any>,
@@ -536,7 +536,7 @@ export function getResizeDist(
     } = moveable.state;
 
     const n = is3d ? 4 : 3;
-    const nextOrigin = caculateTransformOrigin(
+    const nextOrigin = calculateTransformOrigin(
         transformOrigin!,
         width,
         height,

--- a/packages/react-moveable/src/react-moveable/matrix/index.ts
+++ b/packages/react-moveable/src/react-moveable/matrix/index.ts
@@ -272,14 +272,14 @@ export function convertMatrixtoCSS(a: number[], is2d: boolean = a.length === 9) 
     return a;
 }
 
-export function caculate(matrix: number[], matrix2: number[], n: number = matrix2.length) {
+export function calculate(matrix: number[], matrix2: number[], n: number = matrix2.length) {
     const result = multiply(matrix, matrix2, n);
     const k = result[n - 1];
     return result.map(v => v / k);
 }
 
 export function rotate(pos: number[], rad: number) {
-    return caculate(
+    return calculate(
         createRotateMatrix(rad, 3),
         convertPositionMatrix(pos, 3),
     );

--- a/packages/react-moveable/src/react-moveable/types.ts
+++ b/packages/react-moveable/src/react-moveable/types.ts
@@ -686,7 +686,7 @@ export interface OnWarpStart extends OnEvent, OnTransformStartEvent {
  * @property - a target's transform
  * @property - The delta of warp matrix
  * @property - The dist of warp matrix
- * @property - The caculated warp matrix
+ * @property - The calculated warp matrix
  * @property - Multiply function that can multiply previous matrix by warp matrix
  */
 export interface OnWarp extends OnEvent {

--- a/packages/react-moveable/src/react-moveable/utils.ts
+++ b/packages/react-moveable/src/react-moveable/utils.ts
@@ -4,7 +4,7 @@ import { splitBracket, isUndefined, isObject, splitUnit, IObject, hasClass, isAr
 import {
     multiply, invert,
     convertDimension, createIdentityMatrix,
-    createOriginMatrix, convertPositionMatrix, caculate,
+    createOriginMatrix, convertPositionMatrix, calculate,
     multiplies,
     minus,
     getOrigin,
@@ -313,7 +313,7 @@ export function getMatrixStackInfo(
         is3d,
     };
 }
-export function caculateElementInfo(
+export function calculateElementInfo(
     target?: SVGElement | HTMLElement | null,
     container?: SVGElement | HTMLElement | null,
     rootContainer: HTMLElement | SVGElement | null | undefined = container,
@@ -343,11 +343,11 @@ export function caculateElementInfo(
     }
 
     if (target) {
-        const result = caculateMatrixStack(
+        const result = calculateMatrixStack(
             target, container, rootContainer, isAbsolute3d,
             // prevMatrix, prevRootMatrix, prevN,
         );
-        const position = caculateMoveablePosition(
+        const position = calculateMoveablePosition(
             result.allMatrix,
             result.transformOrigin,
             width, height,
@@ -356,7 +356,7 @@ export function caculateElementInfo(
             ...result,
             ...position,
         };
-        const rotationPosition = caculateMoveablePosition(
+        const rotationPosition = calculateMoveablePosition(
             result.allMatrix, [50, 50], 100, 100,
         );
         rotation = getRotationRad([rotationPosition.pos1, rotationPosition.pos2], rotationPosition.direction);
@@ -412,9 +412,9 @@ export function getElementInfo(
     container?: SVGElement | HTMLElement | null,
     rootContainer: SVGElement | HTMLElement | null | undefined = container,
 ) {
-    return caculateElementInfo(target, container, rootContainer, true);
+    return calculateElementInfo(target, container, rootContainer, true);
 }
-export function caculateMatrixStack(
+export function calculateMatrixStack(
     target: SVGElement | HTMLElement,
     container?: SVGElement | HTMLElement | null,
     rootContainer: SVGElement | HTMLElement | null | undefined = container,
@@ -488,7 +488,7 @@ export function caculateMatrixStack(
             offsetMatrix = allMatrix.slice();
         }
 
-        // caculate for SVGElement
+        // calculate for SVGElement
         if (isObject(matrix[n * (n - 1)])) {
             [matrix[n * (n - 1)], matrix[n * (n - 1) + 1]] =
                 getSVGOffset(
@@ -611,11 +611,11 @@ export function getSVGGraphicsOffset(
         origin[1] - top,
     ];
 }
-export function caculatePosition(matrix: number[], pos: number[], n: number) {
-    return caculate(matrix, convertPositionMatrix(pos, n), n);
+export function calculatePosition(matrix: number[], pos: number[], n: number) {
+    return calculate(matrix, convertPositionMatrix(pos, n), n);
 }
-export function caculatePoses(matrix: number[], width: number, height: number, n: number) {
-    return [[0, 0], [width, 0], [0, height], [width, height]].map(pos => caculatePosition(matrix, pos, n));
+export function calculatePoses(matrix: number[], width: number, height: number, n: number) {
+    return [[0, 0], [width, 0], [0, height], [width, height]].map(pos => calculatePosition(matrix, pos, n));
 }
 export function getRect(poses: number[][]) {
     const posesX = poses.map(pos => pos[0]);
@@ -634,8 +634,8 @@ export function getRect(poses: number[][]) {
         height: rectHeight,
     };
 }
-export function caculateRect(matrix: number[], width: number, height: number, n: number) {
-    const poses = caculatePoses(matrix, width, height, n);
+export function calculateRect(matrix: number[], width: number, height: number, n: number) {
+    const poses = calculatePoses(matrix, width, height, n);
 
     return getRect(poses);
 }
@@ -670,8 +670,8 @@ export function getSVGOffset(
         top: prevTop,
         width: prevWidth,
         height: prevHeight,
-    } = caculateRect(mat, width, height, n);
-    const posOrigin = caculatePosition(mat, origin, n);
+    } = calculateRect(mat, width, height, n);
+    const posOrigin = calculatePosition(mat, origin, n);
     const prevOrigin = minus(posOrigin, [prevLeft, prevTop]);
     const rectOrigin = [
         rectLeft + prevOrigin[0] * rectWidth / prevWidth,
@@ -683,8 +683,8 @@ export function getSVGOffset(
     while (++count < 10) {
         const inverseBeforeMatrix = invert(beforeMatrix, n);
         [offset[0], offset[1]] = minus(
-            caculatePosition(inverseBeforeMatrix, rectOrigin, n),
-            caculatePosition(inverseBeforeMatrix, posOrigin, n),
+            calculatePosition(inverseBeforeMatrix, rectOrigin, n),
+            calculatePosition(inverseBeforeMatrix, posOrigin, n),
         );
         const mat2 = multiplies(
             n,
@@ -695,7 +695,7 @@ export function getSVGOffset(
         const {
             left: nextLeft,
             top: nextTop,
-        } = caculateRect(mat2, width, height, n);
+        } = calculateRect(mat2, width, height, n);
         const distLeft = nextLeft - rectLeft;
         const distTop = nextTop - rectTop;
 
@@ -707,7 +707,7 @@ export function getSVGOffset(
     }
     return offset.map(p => Math.round(p));
 }
-export function caculateMoveablePosition(matrix: number[], origin: number[], width: number, height: number) {
+export function calculateMoveablePosition(matrix: number[], origin: number[], width: number, height: number) {
     const is3d = matrix.length === 16;
     const n = is3d ? 4 : 3;
     let [
@@ -715,8 +715,8 @@ export function caculateMoveablePosition(matrix: number[], origin: number[], wid
         [x2, y2],
         [x3, y3],
         [x4, y4],
-    ] = caculatePoses(matrix, width, height, n);
-    let [originX, originY] = caculatePosition(matrix, origin, n);
+    ] = calculatePoses(matrix, width, height, n);
+    let [originX, originY] = calculatePosition(matrix, origin, n);
 
     const left = Math.min(x1, x2, x3, x4);
     const top = Math.min(y1, y2, y3, y4);
@@ -856,12 +856,12 @@ export function getTargetInfo(
     let containerClientRect = resetClientRect();
     let moveableClientRect = resetClientRect();
 
-    const result = caculateElementInfo(
+    const result = calculateElementInfo(
         target, container!, rootContainer!, false, state,
     );
     if (target) {
         const n = result.is3d ? 4 : 3;
-        const beforePosition = caculateMoveablePosition(
+        const beforePosition = calculateMoveablePosition(
             result.offsetMatrix,
             plus(result.transformOrigin, getOrigin(result.targetMatrix, n)),
             result.width, result.height,
@@ -1188,8 +1188,8 @@ export function minOffset(...args: number[]) {
     return args[0];
 }
 
-export function caculateInversePosition(matrix: number[], pos: number[], n: number) {
-    return caculate(
+export function calculateInversePosition(matrix: number[], pos: number[], n: number) {
+    return calculate(
         invert(matrix, n),
         convertPositionMatrix(pos, n),
         n,
@@ -1203,16 +1203,16 @@ export function convertDragDist(state: MoveableManagerState, e: any) {
     const n = is3d ? 4 : 3;
     [
         e.distX, e.distY,
-    ] = caculateInversePosition(rootMatrix, [e.distX, e.distY], n);
+    ] = calculateInversePosition(rootMatrix, [e.distX, e.distY], n);
 
     return e;
 }
 
-export function caculatePadding(
+export function calculatePadding(
     matrix: number[], pos: number[],
     transformOrigin: number[], origin: number[], n: number,
 ) {
-    return minus(caculatePosition(matrix, plus(transformOrigin, pos), n), origin);
+    return minus(calculatePosition(matrix, plus(transformOrigin, pos), n), origin);
 }
 
 export function convertCSSSize(value: number, size: number, isRelative?: boolean) {

--- a/packages/react-moveable/test/unit/TestHelper.ts
+++ b/packages/react-moveable/test/unit/TestHelper.ts
@@ -1,5 +1,5 @@
 import MoveableManager from "../../src/react-moveable/MoveableManager";
-import {  createRotateMatrix, caculate, minus, plus, createIdentityMatrix } from "../../src/react-moveable/matrix";
+import {  createRotateMatrix, calculate, minus, plus, createIdentityMatrix } from "../../src/react-moveable/matrix";
 import { RotatableProps } from "../../src/react-moveable";
 import { getClientRect } from "../../src/react-moveable/utils";
 
@@ -194,7 +194,7 @@ export async function rotate(startInfo: any[], deg: number) {
 
     const m = createRotateMatrix(rad, 3);
     const dist = minus(startClient, absoluteOrigin);
-    const [offsetX, offsetY] = caculate(m, [dist[0], dist[1], 1]);
+    const [offsetX, offsetY] = calculate(m, [dist[0], dist[1], 1]);
     const client = plus(absoluteOrigin, [offsetX, offsetY]);
 
     dispatchEvent(rotationElement, "mousemove", client);
@@ -310,7 +310,7 @@ export function helperCreateWarpMatrix(
     return convertDimension(h, 3, 4);
 }
 
-export function helperCaculate(matrix: number[], matrix2: number[], n: number = matrix2.length) {
+export function helperCalculate(matrix: number[], matrix2: number[], n: number = matrix2.length) {
     const result = multiply(matrix, matrix2, n);
     const k = result[n - 1];
     return result.map(v => v / k);

--- a/packages/react-moveable/test/unit/utils.spec.tsx
+++ b/packages/react-moveable/test/unit/utils.spec.tsx
@@ -2,11 +2,11 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import {
     getTransformMatrix, getAbsoluteMatrix,
-    getSize, caculateMatrixStack,
+    getSize, calculateMatrixStack,
     throttle, throttleArray, isInside, getElementInfo,
 } from "../../src/react-moveable/utils";
-import { getRad, multiply, invert, transpose, createWarpMatrix, caculate } from "../../src/react-moveable/matrix";
-import { helperInvert, helperMultiply, helperCreateWarpMatrix, helperCaculate } from "./TestHelper";
+import { getRad, multiply, invert, transpose, createWarpMatrix, calculate } from "../../src/react-moveable/matrix";
+import { helperInvert, helperMultiply, helperCreateWarpMatrix, helperCalculate } from "./TestHelper";
 
 describe("test utils", () => {
     beforeEach(() => {
@@ -136,7 +136,7 @@ describe("test utils", () => {
         expect(deg7).to.be.equals(270);
         expect(deg8).to.be.equals(315);
     });
-    it("test caculateMatrixStack(HTMLElement)", () => {
+    it("test calculateMatrixStack(HTMLElement)", () => {
         // Given
         ReactDOM.render(
             <div className="c1" style={{
@@ -164,12 +164,12 @@ describe("test utils", () => {
         const c6 = document.querySelector(".c6") as HTMLElement;
 
         // When
-        const stack1 = caculateMatrixStack(c2, document.body, document.body);
-        const stack2 = caculateMatrixStack(c3, document.body, document.body);
-        const stack3 = caculateMatrixStack(c4, document.body, document.body);
-        const stack5 = caculateMatrixStack(c6, c5, c5);
-        const stack6 = caculateMatrixStack(c6, c4, c4);
-        const stack7 = caculateMatrixStack(c6, null, null);
+        const stack1 = calculateMatrixStack(c2, document.body, document.body);
+        const stack2 = calculateMatrixStack(c3, document.body, document.body);
+        const stack3 = calculateMatrixStack(c4, document.body, document.body);
+        const stack5 = calculateMatrixStack(c6, c5, c5);
+        const stack6 = calculateMatrixStack(c6, c4, c4);
+        const stack7 = calculateMatrixStack(c6, null, null);
 
         // Then
         expect(stack1.beforeMatrix).to.be.deep.equals(transpose([2, 0, -252, 0, 2, -252, 0, 0, 1]));
@@ -303,7 +303,7 @@ describe("test utils", () => {
             // Then
             const pp = [...poses, ...nextPoses];
             poses.forEach((pos, j) => {
-                const [x, y] = caculate((createWarpMatrix as any)(...pp), [pos[0], pos[1], 0, 1]);
+                const [x, y] = calculate((createWarpMatrix as any)(...pp), [pos[0], pos[1], 0, 1]);
 
                 expect(x).to.be.closeTo(nextPoses[j][0], 0.01);
                 expect(y).to.be.closeTo(nextPoses[j][1], 0.01);
@@ -320,12 +320,12 @@ describe("test utils", () => {
 
         expect(isInside([30, 30], pos1, pos2, pos3, pos4)).to.be.true;
     });
-    // it("test caculateBoundSize", () => {
-    //     const size1 = caculateBoundSize([100, 100], [0, 0], [100, 50]);
-    //     const size2 = caculateBoundSize([-10, 100], [0, 0], [100, 50]);
-    //     const size3 = caculateBoundSize([100, 100], [0, 0], [100, 50], true);
-    //     const size4 = caculateBoundSize([100, 100], [50, 40], [100, 50], true);
-    //     const size5 = caculateBoundSize([40, 100], [50, 40], [Infinity, 150], true);
+    // it("test calculateBoundSize", () => {
+    //     const size1 = calculateBoundSize([100, 100], [0, 0], [100, 50]);
+    //     const size2 = calculateBoundSize([-10, 100], [0, 0], [100, 50]);
+    //     const size3 = calculateBoundSize([100, 100], [0, 0], [100, 50], true);
+    //     const size4 = calculateBoundSize([100, 100], [50, 40], [100, 50], true);
+    //     const size5 = calculateBoundSize([40, 100], [50, 40], [Infinity, 150], true);
 
     //     expect(size1).to.be.deep.equals([100, 50]);
     //     expect(size2).to.be.deep.equals([0, 50]);


### PR DESCRIPTION
I don't believe this affects any exported functions, but please confirm.

This typo also exists in `demo/static/js`, but I'm assuming that's built from https://github.com/daybrush/scena/tree/master/packages/react-editor?