### PR TITLE
Switches translateZ to translate3d

### DIFF
--- a/packages/react-moveable/src/react-moveable/MoveableManager.tsx
+++ b/packages/react-moveable/src/react-moveable/MoveableManager.tsx
@@ -115,8 +115,8 @@ export default class MoveableManager<T = {}>
                 style={{
                     "position": "absolute",
                     "display": isDisplay ? "block" : "none",
-                    "transform": `translate(${left - parentLeft}px, ${top - parentTop}px, 0)`,
-                    "--zoom": zoom,
+                    "transform": `translate3d(${left - parentLeft}px, ${top - parentTop}px, 0)`,
+                    "--zoom": zoom, 
                     "--zoompx": `${zoom}px`,
                 }}>
                 {this.renderAbles()}

--- a/packages/react-moveable/src/react-moveable/MoveableManager.tsx
+++ b/packages/react-moveable/src/react-moveable/MoveableManager.tsx
@@ -115,7 +115,7 @@ export default class MoveableManager<T = {}>
                 style={{
                     "position": "absolute",
                     "display": isDisplay ? "block" : "none",
-                    "transform": `translate(${left - parentLeft}px, ${top - parentTop}px) translateZ(${translateZ}px)`,
+                    "transform": `translate(${left - parentLeft}px, ${top - parentTop}px, 0)`,
                     "--zoom": zoom,
                     "--zoompx": `${zoom}px`,
                 }}>


### PR DESCRIPTION
Changes the container styles to use a translate3d instead of a regular translate + translateZ. This allows it to be compatible in  Safari with z-indexes. 

Addresses issue #433 

Unaware of it causing any other issues, but this would fix the z-index issue as described here: https://bucketpress.com/css-translate-and-z-index-problems-in-safari-browser