### PR TITLE
fix: vue3 moveable property reference error

### DIFF
--- a/packages/vue3-moveable/src/Moveable.vue
+++ b/packages/vue3-moveable/src/Moveable.vue
@@ -14,7 +14,7 @@ const methods: Record<string, any> = {};
 
 METHODS.forEach((name) => {
   methods[name] = function (this: any, ...args: any[]) {
-    this.moveable[name](...args);
+    this.$_moveable[name](...args);
   };
 });
 const watch: Record<string, any> = {};


### PR DESCRIPTION
fix: vue3 moveable property reference error