### PR TITLE
rotation for custom defined handlers

### DIFF
--- a/packages/react-moveable/src/react-moveable/ables/Clippable.tsx
+++ b/packages/react-moveable/src/react-moveable/ables/Clippable.tsx
@@ -503,7 +503,7 @@ export default {
                 className={prefix("control", "clip-control", "snap-control")}
                 data-clip-index={i}
                 style={{
-                    transform: `translate(${pos[0]}px, ${pos[1]}px) scale(${zoom})`,
+                    transform: `translate(${pos[0]}px, ${pos[1]}px) rotate(${rad}rad) scale(${zoom})`,
                 }}></div>;
         });
 
@@ -513,7 +513,7 @@ export default {
                     className={prefix("control", "clip-control", "clip-radius", "snap-control")}
                     data-clip-index={8 + i}
                     style={{
-                        transform: `translate(${pos[0]}px, ${pos[1]}px) scale(${zoom})`,
+                        transform: `translate(${pos[0]}px, ${pos[1]}px) rotate(${rad}rad) scale(${zoom})`,
                     }}></div>;
             }));
         }


### PR DESCRIPTION
if .moveable-control.moveable-clip-control is overridden to have a different not round design - rotation does not work for clip handlers
this change is allowing to have custom design handlers not to be broken by rotation