### PR TITLE
Fix typos in "How to use" section

### DIFF
--- a/packages/vue-moveable/README.md
+++ b/packages/vue-moveable/README.md
@@ -118,7 +118,7 @@ If you want to check the methods and events, please refer to the [**API document
 </div>
 </template>
 <script>
-import Moveable from 'vue-moveable';
+import Moveable from 'vue3-moveable';
 
 export default {
   name: 'app',


### PR DESCRIPTION
Change the package name from 'vue-moveable' to 'vue3-moveable'