### PR TITLE
Fixing bad type causing type conflict

### DIFF
--- a/packages/react-moveable/src/react-moveable/makeMoveable.ts
+++ b/packages/react-moveable/src/react-moveable/makeMoveable.ts
@@ -1,7 +1,8 @@
+import { IObject } from "@daybrush/utils";
 import { Able } from "./types";
 import { InitialMoveable } from "./InitialMoveable";
 
-export function makeMoveable<T = {}>(
+export function makeMoveable<T extends IObject<any> = {}>(
     ables: Array<Able<T>>): typeof InitialMoveable & (new (...args: any[]) => InitialMoveable<T>) {
     return class Moveable extends InitialMoveable<T> {
         public static defaultAbles = ables;


### PR DESCRIPTION
Without this change, the TypeScript compiler complains that:

> _Type `T` does not satisfy the constraint `IObject<any>`. This type parameter might need an `extends IObject<any>` constraint._

With the above, the error goes away and the project seems to compile fine.

See an example of this error being [reported in another project](https://github.com/GoogleForCreators/web-stories-wp/pull/12397) depending on this here: https://github.com/GoogleForCreators/web-stories-wp/actions/runs/3224004829