### PR TITLE
fix for getOffsetInfo by using element ownerDocument

### DIFF
--- a/packages/react-moveable/src/utils.tsx
+++ b/packages/react-moveable/src/utils.tsx
@@ -130,7 +130,8 @@ export function getOffsetInfo(
     checkZoom?: boolean,
     targetStyle?: CSSStyleDeclaration,
 ) {
-    const documentElement = document.documentElement || document.body;
+    const doc = el && el.ownerDocument ? el.ownerDocument : document;
+    const documentElement = doc.documentElement || doc.body;
     let hasSlot = false;
     let target: HTMLElement | SVGElement | null | undefined;
     let parentSlotElement: HTMLElement | null | undefined;


### PR DESCRIPTION
In part of my app i am using `getElementInfo`, and found it very useful because it provides many information regarding the element. However, this function does not work with elements inside Iframes and throws the following error:

`Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.`

I found that the problem is with the "getOffsetInfo" method that uses the current document, so the `while` loop won't terminate because the document in the Iframe isn't the same.

For this reason, I have created this PR, and I would really appreciate it if you would accept it. Otherwise, I must maintain my own fork of your project.

Thank you. 



