### PR TITLE
Fix infinite loop

### DIFF
--- a/packages/react-moveable/src/utils.tsx
+++ b/packages/react-moveable/src/utils.tsx
@@ -194,7 +194,7 @@ export function getOffsetInfo(
             hasSlot = true;
             parentSlotElement = targetParentNode as HTMLElement;
         }
-        const parentNode = slotParentNode || targetParentNode;
+        const parentNode = targetParentNode;
 
         if (parentNode && parentNode.nodeType === 11) {
             // Shadow Root


### PR DESCRIPTION
Fixes https://github.com/daybrush/moveable/issues/871
`slotParentNode` is always the same `parentNode`:
```
const slotParentNode = el?.assignedSlot?.parentNode;
```
Therefore, `target` for next round doesn't change. This ends in an infinite loop. 
I'm unsure what the purpose of
```
const parentNode = slotParentNode || targetParentNode;
```
was.
Setting
```
const parentNode = targetParentNode;
```
works in my case, but I'm unsure, if it breaks others code.