### PR TITLE
fix(ngx-moveable): make pincheable events available

### DIFF
--- a/packages/ngx-moveable/projects/ngx-moveable/src/ngx-moveable.interface.ts
+++ b/packages/ngx-moveable/projects/ngx-moveable/src/ngx-moveable.interface.ts
@@ -5,7 +5,7 @@ import Moveable, {
 } from 'moveable';
 import { MethodInterface, withMethods } from 'framework-utils';
 
-import { NgxMoveableEvents } from './types';
+import { NgxMoveableEvents, NgxPincheableEvents } from './types';
 
 export class NgxMoveableInterface {
   @withMethods(METHODS, { dragStart: 'ngDragStart' })
@@ -14,6 +14,7 @@ export class NgxMoveableInterface {
 
 export interface NgxMoveableInterface
   extends NgxMoveableEvents,
+    NgxPincheableEvents,
     MoveableProperties,
     MethodInterface<
       MoveableInterface,

--- a/packages/ngx-moveable/projects/ngx-moveable/src/types.ts
+++ b/packages/ngx-moveable/projects/ngx-moveable/src/types.ts
@@ -1,7 +1,27 @@
-import { MoveableEventsParameters, MoveableOptions } from 'moveable';
+import {
+  MoveableEventsParameters,
+  MoveableOptions,
+  OnPinch,
+  OnPinchEnd,
+  OnPinchGroup,
+  OnPinchGroupEnd,
+  OnPinchGroupStart,
+  OnPinchStart,
+} from 'moveable';
 import { EventEmitter } from '@angular/core';
 
 export type RequiredMoveableOptions = Required<MoveableOptions>;
 export type NgxMoveableEvents = {
-  [key in keyof MoveableEventsParameters]: EventEmitter<MoveableEventsParameters[key]>;
+  [key in keyof MoveableEventsParameters]: EventEmitter<
+    MoveableEventsParameters[key]
+  >;
 };
+
+export interface NgxPincheableEvents {
+  pinchStart: EventEmitter<OnPinchStart>;
+  pinch: EventEmitter<OnPinch>;
+  pinchEnd: EventEmitter<OnPinchEnd>;
+  pinchGroupStart: EventEmitter<OnPinchGroupStart>;
+  pinchGroup: EventEmitter<OnPinchGroup>;
+  pinchGroupEnd: EventEmitter<OnPinchGroupEnd>;
+}


### PR DESCRIPTION
Currently, `pinch*` event emitters are not _declared_ on the class:

![Screenshot from 2023-06-05 22-44-48](https://github.com/daybrush/moveable/assets/7337691/458dce52-d013-4a9c-be7a-521988d2bb59)
