### PR TITLE
Add svelte 4 as a compatible dependency

### DIFF
--- a/packages/svelte-moveable/package.json
+++ b/packages/svelte-moveable/package.json
@@ -69,7 +69,7 @@
         "@sveltejs/kit": "^1.5.0",
         "@sveltejs/package": "^2.0.0",
         "publint": "^0.1.9",
-        "svelte": "^3.54.0",
+        "svelte": "^3.54.0 || ^4.0.0",
         "svelte-check": "^3.0.1",
         "tslib": "^2.4.1",
         "typescript": "^4.8 <4.9",


### PR DESCRIPTION
Svelte 4 is out, so lets edit the package.json so that it doesn't cause invalid peer dependency errors.