### PR TITLE
fix: fix typo ( Baisc => Basic )

### DIFF
--- a/packages/react-moveable/stories/1-Basic/0-Basic.stories.tsx
+++ b/packages/react-moveable/stories/1-Basic/0-Basic.stories.tsx
@@ -115,7 +115,7 @@ export const BasicScalableKeepRatioTest = add("Scalable keepRatio Test", {
     },
 });
 
-export const BaiscRotatable = add("Rotatable", {
+export const BasicRotatable = add("Rotatable", {
     app: require("./ReactRotatableApp").default,
     path: require.resolve("./ReactRotatableApp"),
     argsTypes: {

--- a/storybook/stories/1-Basic/react-Basic.stories.tsx
+++ b/storybook/stories/1-Basic/react-Basic.stories.tsx
@@ -120,7 +120,7 @@ export const BasicScalableKeepRatioTest = add("Scalable keepRatio Test", {
     },
 });
 
-export const BaiscRotatable = add("Rotatable", {
+export const BasicRotatable = add("Rotatable", {
     appName: "ReactRotatableApp",
     app: require("./react/ReactRotatableApp").default,
     argsTypes: {


### PR DESCRIPTION
Fix a spelling error that is causing incorrect link access in the README.md file. The link to 'Rotatable' is not working and it displays the error 'Couldn't find story matching 'basic--basic-rotatable'.