### PR TITLE
Add missing dependencies in moveable and svelte-moveable packages

### DIFF
--- a/packages/moveable/package.json
+++ b/packages/moveable/package.json
@@ -68,6 +68,7 @@
     "@scena/event-emitter": "^1.0.5",
     "croact": "^1.0.4",
     "croact-moveable": "~0.9.0",
+    "framework-utils": "^1.1.0",
     "react-moveable": "~0.56.0"
   },
   "devDependencies": {

--- a/packages/svelte-moveable/package.json
+++ b/packages/svelte-moveable/package.json
@@ -76,6 +76,7 @@
         "vite": "^4.3.0"
     },
     "dependencies": {
+        "@daybrush/utils": "^1.13.0",
         "framework-utils": "^1.1.0",
         "moveable": "~0.53.0"
     }


### PR DESCRIPTION
Problem:
When consuming the `svelte-movealbe` package in a pnpm monorepo, `vite build` and `vite dev` fails with error saying "Cannot find module framwork-utils". However, in an npm managed repo, builds are fine. This is because pnpm requires each package to correctly specify direct dependencies, where npm allow dependencies to be shared across packages.

E.g. 
```
A -> B -> C
|         ↑
-----------
```
In this case, A and B both directly depend on C. For npm, if A declares C as a dependency, but B does not, it is fine. For pnpm, both A and B has to declare C as a dependency.

Root Cause:
- The `moveable` package directly depend on `framework-utils`, but missing it as a dependency in its package.json file. 
- The `svelte-moveable` package directly depend on `@daybrush/utils`, but missing it as a dependency in its package.json file.

Solution:
Adding missing dependencies in corresponding package.json files, under `dependencies` field because they are labeled as `external` in the `rollup.config.js` file.