### PR TITLE
Fix package.json

### DIFF
--- a/packages/vue3-moveable/package.json
+++ b/packages/vue3-moveable/package.json
@@ -3,7 +3,7 @@
     "version": "0.28.0",
     "description": "A Vue 3 Component that create Moveable, Draggable, Resizable, Scalable, Rotatable, Warpable, Pinchable, Groupable.",
     "types": "dist/index.d.ts",
-    "main": "dist/moveable.cjs.js",
+    "main": "dist/moveable.cjs",
     "module": "dist/moveable.js",
     "sideEffects": false,
     "type": "module",


### PR DESCRIPTION
**Problem:**

The package.js has been broken for a while now, as we can see [here ](https://publint.dev/vue3-moveable@0.28.0). The last correct version was [0.23.0](https://publint.dev/vue3-moveable@0.23.0). See [issue #1086](https://github.com/daybrush/moveable/issues/1086) for more details.

**Solution:**

Simply fix the path of the main file.